### PR TITLE
fix: undefined column name on optional

### DIFF
--- a/packages/platform/database/migrations/2017_08_22_072402_add_laravolt_attributes_to_users.php
+++ b/packages/platform/database/migrations/2017_08_22_072402_add_laravolt_attributes_to_users.php
@@ -44,7 +44,17 @@ class AddLaravoltAttributesToUsers extends Migration
     public function down()
     {
         Schema::table($this->table, function (Blueprint $table) {
-            $table->dropColumn(['status', 'timezone', 'password_changed_at']);
+            if (Schema::hasColumn($this->table, 'status')) {
+                $table->dropColumn(['status']);
+            }
+
+            if (Schema::hasColumn($this->table, 'timezone')) {
+                $table->dropColumn(['timezone']);
+            }
+
+            if (Schema::hasColumn($this->table, 'password_changed_at')) {
+                $table->dropColumn(['password_changed_at']);
+            }
         });
     }
 }


### PR DESCRIPTION
error ketika menjalankan `php artisan migrate:refresh` karena column optional yang tidak di create.