### PR TITLE
fix: escaping HTML tag

### DIFF
--- a/resources/views/components/inspire.blade.php
+++ b/resources/views/components/inspire.blade.php
@@ -1,1 +1,1 @@
-{{ \Illuminate\Foundation\Inspiring::quote() }}
+{!! \Illuminate\Foundation\Inspiring::quote() !!}


### PR DESCRIPTION
Escape HTML tag from `php artisan inspire` command.

Stack:
- laravel/framework: 9.21.6
- laravolt/laravolt: 5.1.2

Bug:
<img width="776" alt="Screen Shot 2022-07-26 at 14 51 51" src="https://user-images.githubusercontent.com/34129273/180953149-f2896330-212d-41ba-904d-6de670f56538.png">

Fixed:
<img width="776" alt="Screen Shot 2022-07-26 at 14 52 21" src="https://user-images.githubusercontent.com/34129273/180953225-5e610082-dd88-463f-a101-4a01de22567e.png">