### PR TITLE
Update CanGenerateOptionsFromDb.php

### DIFF
--- a/packages/semantic-form/src/Traits/CanGenerateOptionsFromDb.php
+++ b/packages/semantic-form/src/Traits/CanGenerateOptionsFromDb.php
@@ -3,6 +3,7 @@
 namespace Laravolt\SemanticForm\Traits;
 
 use Illuminate\Support\Facades\DB;
+use Illuminate\Database\Query\Grammars\Grammar;
 
 trait CanGenerateOptionsFromDb
 {
@@ -63,7 +64,7 @@ trait CanGenerateOptionsFromDb
         $options = [];
 
         if ($this->query) {
-            $data = DB::connection($this->getConnection())->select(DB::raw($this->query));
+            $data = DB::connection($this->getConnection())->select(DB::raw($this->query)->getValue(new Grammar()));
             $options = collect($data)->mapWithKeys(function ($item) use ($keyColumn, $valueColumn) {
                 $item = (array) $item;
 


### PR DESCRIPTION
Ada error PDO::prepare(): Argument #1 ($query) must be of type string, Illuminate\Database\Query\Expression given di laravel 10.11.0 , PHP 8.1.14, karena hasil dari DB:Raw() yaitu Illuminate\Database\Query\Expression tidak bisa di convert langsung ke string, sehingga perlu tambahan ->getValue(new Grammar) agar dapat di convert jadi string