### PR TITLE
Update CanGenerateOptionsFromDb.php to resolving error PDO::prepare()…

### DIFF
--- a/packages/semantic-form/src/Traits/CanGenerateOptionsFromDb.php
+++ b/packages/semantic-form/src/Traits/CanGenerateOptionsFromDb.php
@@ -63,7 +63,7 @@ trait CanGenerateOptionsFromDb
         $options = [];
 
         if ($this->query) {
-            $data = DB::connection($this->getConnection())->select(DB::raw($this->query));
+            $data = DB::connection($this->getConnection())->select($this->query);
             $options = collect($data)->mapWithKeys(function ($item) use ($keyColumn, $valueColumn) {
                 $item = (array) $item;
 


### PR DESCRIPTION
…: Argument #1 ($query) must be of type string, Illuminate\Database\Query\Expression given