### PR TITLE
feat: implement automatic caching for Chart and Statistic data

### DIFF
--- a/src/Charts/Chart.php
+++ b/src/Charts/Chart.php
@@ -81,8 +81,14 @@ abstract class Chart extends Component
             return $this->cacheKey;
         }
 
-        // Generate a cache key based on class name and any parameters
-        return 'laravolt_chart_' . class_basename($this) . '_' . md5(serialize($this));
+        // Generate a cache key based on class name and relevant properties
+        return 'laravolt_chart_' . class_basename($this) . '_' . md5(json_encode([
+            'title' => $this->title,
+            'type' => $this->type,
+            'height' => $this->height,
+            'sparkline' => $this->sparkline,
+            'series' => $this->series,
+        ]));
     }
 
     public function labels(): array

--- a/src/Ui/Statistic.php
+++ b/src/Ui/Statistic.php
@@ -3,6 +3,7 @@
 namespace Laravolt\Ui;
 
 use Livewire\Component;
+use Illuminate\Support\Facades\Cache;
 
 class Statistic extends Component
 {
@@ -15,6 +16,17 @@ class Statistic extends Component
     public ?string $icon = null;
 
     public ?string $color = null;
+
+    /**
+     * Cache duration in seconds.
+     * Default: 1 hour
+     */
+    protected int $cacheDuration = 3600;
+
+    /**
+     * Custom cache key. If null, a key will be auto-generated.
+     */
+    protected ?string $cacheKey = null;
 
     public function value(): int|string
     {
@@ -39,6 +51,40 @@ class Statistic extends Component
     public function color(): ?string
     {
         return $this->color ?? config('laravolt.ui.color');
+    }
+
+    /**
+     * Load data with caching applied.
+     * This method should be overridden in child classes that need to fetch data.
+     *
+     * @param callable $callback The function that fetches data
+     * @param string|null $customKey Optional custom cache key
+     * @param int|null $duration Optional custom cache duration
+     * @return mixed
+     */
+    protected function loadWithCache(callable $callback, ?string $customKey = null, ?int $duration = null): mixed
+    {
+        $key = $customKey ?? $this->getCacheKey();
+        $cacheDuration = $duration ?? $this->cacheDuration;
+
+        return Cache::remember(
+            $key,
+            $cacheDuration,
+            $callback
+        );
+    }
+
+    /**
+     * Generate or get a cache key for this statistic
+     */
+    protected function getCacheKey(): string
+    {
+        if ($this->cacheKey) {
+            return $this->cacheKey;
+        }
+
+        // Generate a cache key based on class name and any parameters
+        return 'laravolt_statistic_' . class_basename($this) . '_' . md5(serialize($this));
     }
 
     public function render()

--- a/src/Ui/Statistic.php
+++ b/src/Ui/Statistic.php
@@ -83,8 +83,15 @@ class Statistic extends Component
             return $this->cacheKey;
         }
 
-        // Generate a cache key based on class name and any parameters
-        return 'laravolt_statistic_' . class_basename($this) . '_' . md5(serialize($this));
+        // Generate a cache key based on class name and relevant public properties
+        $properties = [
+            'value' => $this->value,
+            'title' => $this->title,
+            'label' => $this->label,
+            'icon' => $this->icon,
+            'color' => $this->color,
+        ];
+        return 'laravolt_statistic_' . class_basename($this) . '_' . md5(serialize($properties));
     }
 
     public function render()


### PR DESCRIPTION
- Add cache duration and custom cache key support to Chart class
- Implement loadSeriesData() method to transparently cache chart data
- Add caching support to Statistic class via loadWithCache() helper
- Set default cache duration to 1 hour
- Generate automatic cache keys based on class name and instance state
- Maintain backward compatibility with existing API
- Follows best practice recommendation for caching complex data processing