### PR TITLE
feat(suitable): add currency column for currency formatting with prefix and suffix

### DIFF
--- a/packages/suitable/src/Columns/Currency.php
+++ b/packages/suitable/src/Columns/Currency.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Laravolt\Suitable\Columns;
+
+class Currency extends Column implements ColumnInterface
+{
+    protected string $prefix = '';
+    protected string $suffix = '';
+    protected int $decimals = 0;
+    protected string $decimalSeparator = ',';
+    protected string $thousandsSeparator = '.';
+
+    public function cell($cell, $collection, $loop)
+    {
+        $value = data_get($cell, $this->field);
+        
+        if ($value === null || $value === '') {
+            return '-';
+        }
+
+        $formatted = number_format($value, $this->decimals, $this->decimalSeparator, $this->thousandsSeparator);
+        
+        return $this->prefix . $formatted . $this->suffix;
+    }
+
+    public function prefix(string $prefix): self
+    {
+        $this->prefix = $prefix;
+        return $this;
+    }
+
+    public function suffix(string $suffix): self
+    {
+        $this->suffix = $suffix;
+        return $this;
+    }
+
+    public function decimals(int $decimals): self
+    {
+        $this->decimals = $decimals;
+        return $this;
+    }
+}


### PR DESCRIPTION
### What this PR does?
This PR introduces a new Currency column for Laravolt Suitable to display numeric values in a properly formatted currency style.

### Key Features
- ✅ prefix(string $prefix) – Add a prefix (e.g., Rp , $).
- ✅ suffix(string $suffix) – Add a suffix (e.g., ,-).
- ✅ decimals(int $decimals) – Define how many decimals to show.
- ✅ Default locale-friendly formatting – Uses . for thousand separator and , for decimal separator (Indonesian style).
- ✅ Graceful fallback – Returns - if the value is null or empty.

### Usage Example
```php
<?php

class Example extends TableView
{
    public function columns(): array
    {
        return [
            Currency::make('price', 'Pricing')
                ->prefix('Rp ')
                ->suffix(',-')
                ->decimals(0)
                ->sortable(),
        ]
    }
}
```

### Output
```bash
Rp 1.500.000,-
```