### PR TITLE
Fix menu registration memory leaks

### DIFF
--- a/src/Platform/Providers/UiServiceProvider.php
+++ b/src/Platform/Providers/UiServiceProvider.php
@@ -122,6 +122,9 @@ class UiServiceProvider extends BaseServiceProvider
         View::composer(
             'laravolt::menu.sidebar',
             function () {
+                // Ensure dynamic registrations do not accumulate across requests/renders
+                $this->app['laravolt.menu.sidebar']->resetDynamic();
+
                 foreach (config('laravolt.menu') as $menu) {
                     $this->app['laravolt.menu.builder']->loadArray($menu);
                 }

--- a/src/Platform/Services/MenuBuilder.php
+++ b/src/Platform/Services/MenuBuilder.php
@@ -25,7 +25,7 @@ class MenuBuilder
     public function runCallbacks()
     {
         foreach ($this->registeredCallbacks as $callback) {
-            app('laravolt.menu.sidebar')->registerCore($callback);
+            app('laravolt.menu.sidebar')->register($callback);
         }
     }
 
@@ -38,7 +38,7 @@ class MenuBuilder
                 $order = $option['order'] ?? 50;
             }
 
-            app('laravolt.menu.sidebar')->registerCore(
+            app('laravolt.menu.sidebar')->register(
                 function ($sidebar) use ($title, $option, $order) {
                     /** @var \Lavary\Menu\Builder $section */
                     $section = $sidebar->get(strtolower(trim($title)));

--- a/src/Platform/Services/SidebarMenu.php
+++ b/src/Platform/Services/SidebarMenu.php
@@ -25,6 +25,11 @@ class SidebarMenu extends BaseMenu
         $this->callbacks[] = $callback;
     }
 
+    public function resetDynamic(): void
+    {
+        $this->callbacks = [];
+    }
+
     public static function setVisible($children, $visible = 'visible')
     {
         foreach ($children as $child) {


### PR DESCRIPTION
Prevent memory leaks by resetting dynamic menu registrations on each request.

Dynamic menu registrations were accumulating in long-running processes (e.g., Octane/Swoole), leading to memory leaks. This change ensures that dynamic menu callbacks are cleared before each menu build, preventing their accumulation across requests.

---
<a href="https://cursor.com/background-agent?bcId=bc-9e1ba319-8476-4e3d-b798-72f73c5a65c8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9e1ba319-8476-4e3d-b798-72f73c5a65c8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

