### PR TITLE
Laravel Octane best practices guide

### DIFF
--- a/src/Platform/Components/ComponentManager.php
+++ b/src/Platform/Components/ComponentManager.php
@@ -5,4 +5,9 @@ namespace Laravolt\Platform\Components;
 class ComponentManager
 {
     public static ?string $currentComponent = null;
+
+    public static function reset(): void
+    {
+        self::$currentComponent = null;
+    }
 }

--- a/src/Platform/Components/Tab.php
+++ b/src/Platform/Components/Tab.php
@@ -15,6 +15,11 @@ class Tab extends Component
         return static::$activeTab;
     }
 
+    public static function resetActiveTab(): void
+    {
+        static::$activeTab = null;
+    }
+
     public function __construct()
     {
         $this->key = 'tab-'.bin2hex(random_bytes(5));


### PR DESCRIPTION
Add Octane request termination listeners to reset static UI state and prevent cross-request data leakage.

---
<a href="https://cursor.com/background-agent?bcId=bc-e905b476-6f41-4360-be4b-5aa425219b5a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e905b476-6f41-4360-be4b-5aa425219b5a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

