### PR TITLE
Implement missing prelineform api methods

### DIFF
--- a/packages/preline-form/src/Elements/ActionWrapper.php
+++ b/packages/preline-form/src/Elements/ActionWrapper.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Laravolt\PrelineForm\Elements;
+
+class ActionWrapper extends Element
+{
+    protected $actions;
+
+    public function __construct($actions)
+    {
+        $this->actions = $actions;
+    }
+
+    public function render()
+    {
+        $result = '<div class="flex gap-2">';
+
+        foreach ($this->actions as $action) {
+            $result .= $action->render();
+        }
+
+        $result .= '</div>';
+
+        return $result;
+    }
+}

--- a/packages/preline-form/src/Elements/DateTime.php
+++ b/packages/preline-form/src/Elements/DateTime.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Laravolt\PrelineForm\Elements;
+
+class DateTime extends Element
+{
+    protected $attributes = [
+        'type' => 'datetime-local',
+        'class' => 'w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500'
+    ];
+
+    public function __construct($name)
+    {
+        $this->setName($name);
+    }
+
+    public function render()
+    {
+        return '<input' . $this->renderAttributes() . '>';
+    }
+}

--- a/packages/preline-form/src/Elements/FormOpen.php
+++ b/packages/preline-form/src/Elements/FormOpen.php
@@ -118,8 +118,6 @@ class FormOpen extends Element
     {
         return ! is_null($this->hiddenMethod);
     }
-<<<<<<< Current (Your changes)
-=======
 
     public function horizontal()
     {
@@ -140,5 +138,4 @@ class FormOpen extends Element
     {
         return $this->encodingType('multipart/form-data');
     }
->>>>>>> Incoming (Background Agent changes)
 }

--- a/packages/preline-form/src/Elements/SelectDateTimeWrapper.php
+++ b/packages/preline-form/src/Elements/SelectDateTimeWrapper.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Laravolt\PrelineForm\Elements;
+
+class SelectDateTimeWrapper extends Element
+{
+    protected $date;
+    protected $month;
+    protected $year;
+    protected $time;
+
+    public function __construct($date, $month, $year, $time)
+    {
+        $this->date = $date;
+        $this->month = $month;
+        $this->year = $year;
+        $this->time = $time;
+    }
+
+    public function render()
+    {
+        $result = '<div class="grid grid-cols-4 gap-2">';
+        $result .= $this->date->render();
+        $result .= $this->month->render();
+        $result .= $this->year->render();
+        $result .= $this->time->render();
+        $result .= '</div>';
+
+        return $result;
+    }
+
+    public function value($value)
+    {
+        if ($value instanceof \Carbon\Carbon) {
+            // Set individual components
+            $this->date->element->value($value->day);
+            $this->month->element->value($value->month);
+            $this->year->element->value($value->year);
+            $this->time->element->value($value->format('H:i'));
+        }
+
+        return $this;
+    }
+}

--- a/packages/preline-form/src/Elements/SelectDateWrapper.php
+++ b/packages/preline-form/src/Elements/SelectDateWrapper.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Laravolt\PrelineForm\Elements;
+
+class SelectDateWrapper extends Element
+{
+    protected $date;
+    protected $month;
+    protected $year;
+
+    public function __construct($date, $month, $year)
+    {
+        $this->date = $date;
+        $this->month = $month;
+        $this->year = $year;
+    }
+
+    public function render()
+    {
+        $result = '<div class="grid grid-cols-3 gap-2">';
+        $result .= $this->date->render();
+        $result .= $this->month->render();
+        $result .= $this->year->render();
+        $result .= '</div>';
+
+        return $result;
+    }
+}

--- a/packages/semantic-form/src/SemanticForm.php
+++ b/packages/semantic-form/src/SemanticForm.php
@@ -733,6 +733,17 @@ class SemanticForm
         return new FieldCollection($fields);
     }
 
+    public function mapping($fields, $callback = null)
+    {
+        // Allow mapping over fields with an optional callback
+        if ($callback) {
+            return collect($fields)->map($callback);
+        }
+        
+        // Or return the fields as-is for further processing
+        return collect($fields);
+    }
+
     protected function getTimeOptions($interval)
     {
         $times = [];


### PR DESCRIPTION
Achieve full API compatibility between `PrelineForm` and `SemanticForm` by implementing missing methods and elements, and add a `mapping` method to `SemanticForm`.

This resolves the "Method Laravolt\PrelineForm\PrelineForm::action does not exist" error by fixing a merge conflict and implementing the `action` method for button wrapping. It also adds other missing methods and their corresponding element classes (or stubs for complex ones) to ensure `PrelineForm` mirrors `SemanticForm`'s API, facilitating a smooth migration.

---
<a href="https://cursor.com/background-agent?bcId=bc-5df19e1e-84ad-4b13-98dc-e3f41abf2643">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5df19e1e-84ad-4b13-98dc-e3f41abf2643">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

