### PR TITLE
Align prelineform structure with semanticform

### DIFF
--- a/packages/preline-form/src/Elements/Button.php
+++ b/packages/preline-form/src/Elements/Button.php
@@ -2,15 +2,23 @@
 
 namespace Laravolt\PrelineForm\Elements;
 
-class Button extends Element
+class Button extends FormControl
 {
-    protected $value;
+    protected $attributes = [
+        'type' => 'button',
+    ];
+
+    protected $text;
 
     protected $type;
 
-    public function __construct($value, $type = 'button')
+    public function __construct($text, $name = null, $type = 'button')
     {
-        $this->value = $value;
+        if ($name) {
+            parent::__construct($name);
+        }
+        
+        $this->text = $text;
         $this->type = $type;
         $this->setAttribute('type', $type);
         $this->setDefaultClasses();
@@ -59,13 +67,15 @@ class Button extends Element
 
     public function text($text)
     {
-        $this->value = $text;
+        $this->text = $text;
 
         return $this;
     }
 
     public function render()
     {
-        return sprintf('<button%s>%s</button>', $this->renderAttributes(), form_escape($this->value));
+        $this->beforeRender();
+
+        return sprintf('<button%s>%s</button>', $this->renderAttributes(), form_escape($this->text));
     }
 }

--- a/packages/preline-form/src/Elements/Button.php
+++ b/packages/preline-form/src/Elements/Button.php
@@ -14,9 +14,7 @@ class Button extends FormControl
 
     public function __construct($text, $name = null, $type = 'button')
     {
-        if ($name) {
-            parent::__construct($name);
-        }
+        parent::__construct($name);
         
         $this->text = $text;
         $this->type = $type;

--- a/packages/preline-form/src/Elements/Checkbox.php
+++ b/packages/preline-form/src/Elements/Checkbox.php
@@ -77,7 +77,7 @@ class Checkbox extends Input
 
     public function setError($message = '')
     {
-        parent::setError(true);
+        parent::setError();
         $this->errorMessage = $message;
         $this->removeClass('border-gray-200 focus:ring-blue-500');
         $this->addClass('border-red-500 focus:ring-red-500');

--- a/packages/preline-form/src/Elements/Checkbox.php
+++ b/packages/preline-form/src/Elements/Checkbox.php
@@ -2,15 +2,13 @@
 
 namespace Laravolt\PrelineForm\Elements;
 
-class Checkbox extends Element
+class Checkbox extends Input
 {
-    protected $name;
-
-    protected $value;
+    protected $attributes = [
+        'type' => 'checkbox',
+    ];
 
     protected $checked = false;
-
-    protected $hasError = false;
 
     protected $errorMessage = '';
 
@@ -18,11 +16,8 @@ class Checkbox extends Element
 
     public function __construct($name, $value = 1)
     {
-        $this->name = $name;
-        $this->value = $value;
-        $this->setAttribute('type', 'checkbox');
-        $this->setAttribute('name', $name);
-        $this->setAttribute('value', $value);
+        parent::__construct($name);
+        $this->setValue($value);
         $this->setDefaultClasses();
     }
 
@@ -82,7 +77,7 @@ class Checkbox extends Element
 
     public function setError($message = '')
     {
-        $this->hasError = true;
+        parent::setError(true);
         $this->errorMessage = $message;
         $this->removeClass('border-gray-200 focus:ring-blue-500');
         $this->addClass('border-red-500 focus:ring-red-500');
@@ -90,9 +85,9 @@ class Checkbox extends Element
         return $this;
     }
 
-    protected function hasError()
+    public function hasError()
     {
-        return $this->hasError;
+        return parent::hasError();
     }
 
     protected function getError()

--- a/packages/preline-form/src/Elements/Element.php
+++ b/packages/preline-form/src/Elements/Element.php
@@ -168,67 +168,7 @@ abstract class Element
         return $this;
     }
 
-    // Form control methods for compatibility
-    public function required($required = true)
-    {
-        if ($required) {
-            $this->setAttribute('required', 'required');
-        } else {
-            $this->removeAttribute('required');
-        }
 
-        return $this;
-    }
-
-    public function optional()
-    {
-        $this->removeAttribute('required');
-
-        return $this;
-    }
-
-    public function readonly($readonly = true)
-    {
-        if ($readonly) {
-            $this->setAttribute('readonly', 'readonly');
-        } else {
-            $this->removeAttribute('readonly');
-        }
-
-        return $this;
-    }
-
-    public function disable($disable = true)
-    {
-        if ($disable) {
-            $this->setAttribute('disabled', 'disabled');
-        } else {
-            $this->removeAttribute('disabled');
-        }
-
-        return $this;
-    }
-
-    public function enable($enable = true)
-    {
-        $this->disable(! $enable);
-
-        return $this;
-    }
-
-    public function autofocus()
-    {
-        $this->setAttribute('autofocus', 'autofocus');
-
-        return $this;
-    }
-
-    public function unfocus()
-    {
-        $this->removeAttribute('autofocus');
-
-        return $this;
-    }
 
     public function getValue()
     {

--- a/packages/preline-form/src/Elements/File.php
+++ b/packages/preline-form/src/Elements/File.php
@@ -37,7 +37,7 @@ class File extends Input
 
     public function setError($message = '')
     {
-        parent::setError(true);
+        parent::setError();
         $this->errorMessage = $message;
         $this->removeClass('border-gray-200 focus:border-blue-500 focus:ring-blue-500');
         $this->addClass('border-red-500 focus:border-red-500 focus:ring-red-500');

--- a/packages/preline-form/src/Elements/File.php
+++ b/packages/preline-form/src/Elements/File.php
@@ -2,19 +2,17 @@
 
 namespace Laravolt\PrelineForm\Elements;
 
-class File extends Element
+class File extends Input
 {
-    protected $name;
-
-    protected $hasError = false;
+    protected $attributes = [
+        'type' => 'file',
+    ];
 
     protected $errorMessage = '';
 
     public function __construct($name)
     {
-        $this->name = $name;
-        $this->setAttribute('type', 'file');
-        $this->setAttribute('name', $name);
+        parent::__construct($name);
         $this->setDefaultClasses();
     }
 
@@ -39,7 +37,7 @@ class File extends Element
 
     public function setError($message = '')
     {
-        $this->hasError = true;
+        parent::setError(true);
         $this->errorMessage = $message;
         $this->removeClass('border-gray-200 focus:border-blue-500 focus:ring-blue-500');
         $this->addClass('border-red-500 focus:border-red-500 focus:ring-red-500');
@@ -47,19 +45,14 @@ class File extends Element
         return $this;
     }
 
-    protected function hasError()
+    public function hasError()
     {
-        return $this->hasError;
+        return parent::hasError();
     }
 
     protected function getError()
     {
         return $this->errorMessage;
-    }
-
-    protected function renderControl()
-    {
-        return sprintf('<input%s>', $this->renderAttributes());
     }
 
     public function render()
@@ -68,6 +61,18 @@ class File extends Element
             return $this->renderField();
         }
 
-        return $this->renderControl();
+        $this->beforeRender();
+
+        $result = '<input';
+        $result .= $this->renderAttributes();
+        $result .= '>';
+        $result .= $this->renderHint();
+
+        return $result;
+    }
+
+    protected function renderControl()
+    {
+        return sprintf('<input%s>', $this->renderAttributes());
     }
 }

--- a/packages/preline-form/src/Elements/FormControl.php
+++ b/packages/preline-form/src/Elements/FormControl.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Laravolt\PrelineForm\Elements;
+
+abstract class FormControl extends Element
+{
+    protected $hasError = false;
+
+    protected $value;
+
+    public function __construct($name)
+    {
+        $this->setName($name);
+    }
+
+    protected function setName($name)
+    {
+        $this->setAttribute('name', $name);
+    }
+
+    public function readonly($readonly = true)
+    {
+        if ($readonly) {
+            $this->setAttribute('readonly', 'readonly');
+        } else {
+            $this->removeAttribute('readonly');
+        }
+
+        return $this;
+    }
+
+    public function required($required = true)
+    {
+        if ($required) {
+            $this->setAttribute('required', 'required');
+        } else {
+            $this->removeAttribute('required');
+        }
+
+        return $this;
+    }
+
+    public function optional()
+    {
+        $this->removeAttribute('required');
+
+        return $this;
+    }
+
+    public function disable($disable = true)
+    {
+        if ($disable) {
+            $this->setAttribute('disabled', 'disabled');
+        } else {
+            $this->removeAttribute('disabled');
+        }
+
+        return $this;
+    }
+
+    public function enable($enable = true)
+    {
+        $this->disable(! $enable);
+
+        return $this;
+    }
+
+    public function autofocus()
+    {
+        $this->setAttribute('autofocus', 'autofocus');
+
+        return $this;
+    }
+
+    public function unfocus()
+    {
+        $this->removeAttribute('autofocus');
+
+        return $this;
+    }
+
+    public function setError($error = true)
+    {
+        $this->hasError = $error;
+
+        return $this;
+    }
+
+    public function hasError()
+    {
+        return $this->hasError;
+    }
+
+    public function getValue()
+    {
+        return $this->value ?? $this->getAttribute('value');
+    }
+}

--- a/packages/preline-form/src/Elements/Hidden.php
+++ b/packages/preline-form/src/Elements/Hidden.php
@@ -2,22 +2,20 @@
 
 namespace Laravolt\PrelineForm\Elements;
 
-class Hidden extends Element
+class Hidden extends Input
 {
-    protected $name;
-
-    protected $value;
+    protected $attributes = [
+        'type' => 'hidden',
+    ];
 
     public function __construct($name)
     {
-        $this->name = $name;
-        $this->setAttribute('type', 'hidden');
-        $this->setAttribute('name', $name);
+        parent::__construct($name);
     }
 
     public function value($value)
     {
-        $this->setAttribute('value', $value);
+        $this->setValue($value);
 
         return $this;
     }
@@ -33,6 +31,12 @@ class Hidden extends Element
 
     public function render()
     {
-        return sprintf('<input%s>', $this->renderAttributes());
+        $this->beforeRender();
+
+        $result = '<input';
+        $result .= $this->renderAttributes();
+        $result .= '>';
+
+        return $result;
     }
 }

--- a/packages/preline-form/src/Elements/Input.php
+++ b/packages/preline-form/src/Elements/Input.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Laravolt\PrelineForm\Elements;
+
+abstract class Input extends FormControl
+{
+    public function render()
+    {
+        if ($this->label) {
+            $element = clone $this;
+            $element->label = false;
+
+            return $this->decorateField(new Field($this->label, $element))->render();
+        }
+
+        $this->beforeRender();
+
+        $result = '<input';
+        $result .= $this->renderAttributes();
+        $result .= '>';
+        $result .= $this->renderHint();
+
+        return $result;
+    }
+
+    public function value($value)
+    {
+        $this->setValue($value);
+
+        return $this;
+    }
+
+    protected function setValue($value)
+    {
+        $this->setAttribute('value', $value);
+
+        return $this;
+    }
+
+    protected function decorateField(Field $field)
+    {
+        if ($this->fieldCallback instanceof \Closure) {
+            call_user_func($this->fieldCallback, $field);
+        }
+
+        return $field;
+    }
+}

--- a/packages/preline-form/src/Elements/RadioButton.php
+++ b/packages/preline-form/src/Elements/RadioButton.php
@@ -2,25 +2,21 @@
 
 namespace Laravolt\PrelineForm\Elements;
 
-class RadioButton extends Element
+class RadioButton extends Checkbox
 {
-    protected $name;
-
-    protected $value;
-
-    protected $checked = false;
-
-    protected $hasError = false;
-
-    protected $errorMessage = '';
+    protected $attributes = [
+        'type' => 'radio',
+    ];
 
     public function __construct($name, $value = null)
     {
-        $this->name = $name;
-        $this->value = $value;
-        $this->setAttribute('type', 'radio');
-        $this->setAttribute('name', $name);
-        $this->setAttribute('value', $value);
+        parent::__construct($name);
+
+        if (is_null($value)) {
+            $value = $name;
+        }
+
+        $this->setValue($value);
         $this->setDefaultClasses();
     }
 
@@ -65,25 +61,7 @@ class RadioButton extends Element
         return $this->checked(false);
     }
 
-    public function setError($message = '')
-    {
-        $this->hasError = true;
-        $this->errorMessage = $message;
-        $this->removeClass('border-gray-200 focus:ring-blue-500');
-        $this->addClass('border-red-500 focus:ring-red-500');
 
-        return $this;
-    }
-
-    protected function hasError()
-    {
-        return $this->hasError;
-    }
-
-    protected function getError()
-    {
-        return $this->errorMessage;
-    }
 
     public function displayValue()
     {

--- a/packages/preline-form/src/Elements/Select.php
+++ b/packages/preline-form/src/Elements/Select.php
@@ -2,15 +2,11 @@
 
 namespace Laravolt\PrelineForm\Elements;
 
-class Select extends Element
+class Select extends FormControl
 {
-    protected $name;
-
     protected $options = [];
 
     protected $selectedValue;
-
-    protected $hasError = false;
 
     protected $errorMessage = '';
 
@@ -18,9 +14,8 @@ class Select extends Element
 
     public function __construct($name, $options = [])
     {
-        $this->name = $name;
+        parent::__construct($name);
         $this->options = $options;
-        $this->setAttribute('name', $name);
         $this->setDefaultClasses();
     }
 
@@ -102,7 +97,7 @@ class Select extends Element
 
     public function setError($message = '')
     {
-        $this->hasError = true;
+        parent::setError(true);
         $this->errorMessage = $message;
         $this->removeClass('border-gray-200 focus:border-blue-500 focus:ring-blue-500');
         $this->addClass('border-red-500 focus:border-red-500 focus:ring-red-500');
@@ -110,9 +105,9 @@ class Select extends Element
         return $this;
     }
 
-    protected function hasError()
+    public function hasError()
     {
-        return $this->hasError;
+        return parent::hasError();
     }
 
     protected function getError()

--- a/packages/preline-form/src/Elements/Select.php
+++ b/packages/preline-form/src/Elements/Select.php
@@ -97,7 +97,7 @@ class Select extends FormControl
 
     public function setError($message = '')
     {
-        parent::setError(true);
+        parent::setError();
         $this->errorMessage = $message;
         $this->removeClass('border-gray-200 focus:border-blue-500 focus:ring-blue-500');
         $this->addClass('border-red-500 focus:border-red-500 focus:ring-red-500');

--- a/packages/preline-form/src/Elements/Text.php
+++ b/packages/preline-form/src/Elements/Text.php
@@ -2,19 +2,17 @@
 
 namespace Laravolt\PrelineForm\Elements;
 
-class Text extends Element
+class Text extends Input
 {
-    protected $name;
-
-    protected $hasError = false;
+    protected $attributes = [
+        'type' => 'text',
+    ];
 
     protected $errorMessage = '';
 
     public function __construct($name)
     {
-        $this->name = $name;
-        $this->setAttribute('type', 'text');
-        $this->setAttribute('name', $name);
+        parent::__construct($name);
         $this->setDefaultClasses();
     }
 
@@ -25,7 +23,7 @@ class Text extends Element
 
     public function value($value)
     {
-        $this->setAttribute('value', $value);
+        $this->setValue($value);
 
         return $this;
     }
@@ -48,7 +46,7 @@ class Text extends Element
 
     public function setError($message = '')
     {
-        $this->hasError = true;
+        parent::setError(true);
         $this->errorMessage = $message;
         $this->removeClass('border-gray-200 focus:border-blue-500 focus:ring-blue-500');
         $this->addClass('border-red-500 focus:border-red-500 focus:ring-red-500');
@@ -56,14 +54,19 @@ class Text extends Element
         return $this;
     }
 
+    public function hasError()
+    {
+        return parent::hasError();
+    }
+
     protected function getError()
     {
         return $this->errorMessage;
     }
 
-    protected function renderControl()
+    protected function hasValue()
     {
-        return sprintf('<input%s>', $this->renderAttributes());
+        return isset($this->attributes['value']);
     }
 
     public function render()
@@ -72,6 +75,18 @@ class Text extends Element
             return $this->renderField();
         }
 
-        return $this->renderControl();
+        $this->beforeRender();
+
+        $result = '<input';
+        $result .= $this->renderAttributes();
+        $result .= '>';
+        $result .= $this->renderHint();
+
+        return $result;
+    }
+
+    protected function renderControl()
+    {
+        return sprintf('<input%s>', $this->renderAttributes());
     }
 }

--- a/packages/preline-form/src/Elements/Text.php
+++ b/packages/preline-form/src/Elements/Text.php
@@ -46,7 +46,7 @@ class Text extends Input
 
     public function setError($message = '')
     {
-        parent::setError(true);
+        parent::setError();
         $this->errorMessage = $message;
         $this->removeClass('border-gray-200 focus:border-blue-500 focus:ring-blue-500');
         $this->addClass('border-red-500 focus:border-red-500 focus:ring-red-500');

--- a/packages/preline-form/src/Elements/TextArea.php
+++ b/packages/preline-form/src/Elements/TextArea.php
@@ -61,7 +61,7 @@ class TextArea extends FormControl
 
     public function setError($message = '')
     {
-        parent::setError(true);
+        parent::setError();
         $this->errorMessage = $message;
         $this->removeClass('border-gray-200 focus:border-blue-500 focus:ring-blue-500');
         $this->addClass('border-red-500 focus:border-red-500 focus:ring-red-500');

--- a/packages/preline-form/src/Elements/TextArea.php
+++ b/packages/preline-form/src/Elements/TextArea.php
@@ -2,20 +2,18 @@
 
 namespace Laravolt\PrelineForm\Elements;
 
-class TextArea extends Element
+class TextArea extends FormControl
 {
-    protected $name;
-
-    protected $value;
-
-    protected $hasError = false;
+    protected $attributes = [
+        'rows' => 10,
+        'cols' => 50,
+    ];
 
     protected $errorMessage = '';
 
     public function __construct($name)
     {
-        $this->name = $name;
-        $this->setAttribute('name', $name);
+        parent::__construct($name);
         $this->setDefaultClasses();
     }
 
@@ -63,7 +61,7 @@ class TextArea extends Element
 
     public function setError($message = '')
     {
-        $this->hasError = true;
+        parent::setError(true);
         $this->errorMessage = $message;
         $this->removeClass('border-gray-200 focus:border-blue-500 focus:ring-blue-500');
         $this->addClass('border-red-500 focus:border-red-500 focus:ring-red-500');
@@ -71,9 +69,14 @@ class TextArea extends Element
         return $this;
     }
 
-    protected function hasError()
+    public function hasError()
     {
-        return $this->hasError;
+        return parent::hasError();
+    }
+
+    protected function hasValue()
+    {
+        return isset($this->value);
     }
 
     protected function getError()
@@ -81,17 +84,38 @@ class TextArea extends Element
         return $this->errorMessage;
     }
 
+    public function render()
+    {
+        if ($this->label) {
+            $element = clone $this;
+            $element->label = false;
+
+            return $this->decorateField(new Field($this->label, $element))->render();
+        }
+
+        $this->beforeRender();
+
+        $result = '<textarea';
+        $result .= $this->renderAttributes();
+        $result .= '>';
+        $result .= form_escape($this->getValue());
+        $result .= '</textarea>';
+        $result .= $this->renderHint();
+
+        return $result;
+    }
+
     protected function renderControl()
     {
         return sprintf('<textarea%s>%s</textarea>', $this->renderAttributes(), form_escape($this->value ?? ''));
     }
 
-    public function render()
+    protected function decorateField(Field $field)
     {
-        if ($this->label) {
-            return $this->renderField();
+        if ($this->fieldCallback instanceof \Closure) {
+            call_user_func($this->fieldCallback, $field);
         }
 
-        return $this->renderControl();
+        return $field;
     }
 }


### PR DESCRIPTION
Restructure PrelineForm class hierarchy to match SemanticForm, introducing `FormControl` and `Input` abstract classes for improved organization and inheritance.

The original PrelineForm elements directly extended `Element`, leading to duplicated form control logic (e.g., `required`, `readonly`, `setError`) across multiple classes. By introducing `FormControl` and `Input` abstract classes, common behaviors are centralized, promoting code reuse, consistency, and easier maintenance, mirroring the robust structure of SemanticForm.

---
<a href="https://cursor.com/background-agent?bcId=bc-0fd16c9c-3b48-4d12-ac7e-6d6f847b9c3f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0fd16c9c-3b48-4d12-ac7e-6d6f847b9c3f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

