### PR TITLE
Implement chunked uploads for large files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,8 @@
         "spatie/laravel-medialibrary": "^11.12.6",
         "spatie/laravel-web-tinker": "^1.10.1",
         "spatie/once": "^3.1.1",
-        "spaze/phpstan-disallowed-calls": "^4.6"
+        "spaze/phpstan-disallowed-calls": "^4.6",
+        "pion/laravel-chunk-upload": "^1.3"
     },
     "require-dev": {
         "laravel/pint": "^1.21",

--- a/packages/media/README-CHUNKED-UPLOAD.md
+++ b/packages/media/README-CHUNKED-UPLOAD.md
@@ -1,0 +1,357 @@
+# Laravolt Chunked Upload
+
+Dukungan chunked upload untuk Laravolt Media Package yang memungkinkan upload file besar tanpa mengubah konfigurasi PHP/nginx.
+
+## Fitur
+
+- ✅ Upload file besar dengan chunking (pemecahan file)
+- ✅ Resume upload yang terputus
+- ✅ Dukungan untuk user terautentikasi dan Guest
+- ✅ Integrasi dengan Spatie Media Library
+- ✅ Dua opsi frontend: Resumable.js dan FilePond
+- ✅ Cleanup otomatis chunk sementara
+- ✅ Response format konsisten dengan handler lainnya
+- ✅ Backward compatible dengan handler yang ada
+
+## Instalasi
+
+### 1. Install Dependency
+
+Tambahkan dependency ke `composer.json`:
+
+```bash
+composer require pion/laravel-chunk-upload
+```
+
+### 2. Publish Konfigurasi (Opsional)
+
+```bash
+php artisan vendor:publish --provider="Pion\Laravel\ChunkUpload\Providers\ChunkUploadServiceProvider"
+```
+
+### 3. Setup Cleanup Job (Opsional)
+
+Tambahkan ke `app/Console/Kernel.php` untuk cleanup otomatis:
+
+```php
+protected function schedule(Schedule $schedule)
+{
+    // Cleanup chunk files older than 24 hours
+    $schedule->job(new \Laravolt\Media\Jobs\CleanupChunksJob(24))->daily();
+}
+```
+
+## Penggunaan
+
+### Backend API
+
+#### Endpoint Upload Chunk
+
+```http
+POST /media/chunk
+Content-Type: multipart/form-data
+
+file: [chunk file]
+handler: chunked
+_action: upload
+```
+
+**Response:**
+```json
+{
+    "success": true,
+    "done": 50,
+    "chunk": 5,
+    "total_chunks": 10
+}
+```
+
+#### Endpoint Complete Upload
+
+```http
+POST /media/chunk/complete
+Content-Type: application/json
+
+{
+    "handler": "chunked",
+    "_action": "complete",
+    "file_id": "unique-file-id",
+    "file_name": "original-filename.ext"
+}
+```
+
+**Response:**
+```json
+{
+    "success": true,
+    "files": [
+        {
+            "file": "https://example.com/media/123/filename.ext",
+            "name": "filename.ext",
+            "size": 1048576,
+            "type": "image/jpeg",
+            "data": {
+                "id": 123,
+                "url": "https://example.com/media/123/filename.ext",
+                "thumbnail": "https://example.com/media/123/filename.ext"
+            }
+        }
+    ]
+}
+```
+
+#### Endpoint Delete Media
+
+```http
+POST /media/chunk
+Content-Type: application/json
+
+{
+    "handler": "chunked",
+    "_action": "delete",
+    "id": 123
+}
+```
+
+### Frontend Implementation
+
+#### 1. Resumable.js
+
+```html
+<!DOCTYPE html>
+<html>
+<head>
+    <meta name="csrf-token" content="{{ csrf_token() }}">
+    <script src="https://cdn.jsdelivr.net/npm/resumablejs@1.1.0/resumable.min.js"></script>
+</head>
+<body>
+    <div id="drop-zone">
+        <p>Drag and drop files here</p>
+        <input type="file" id="file-input" multiple>
+    </div>
+    
+    <div id="progress-bar" style="width: 100%; height: 20px; background: #f0f0f0;">
+        <div id="progress-fill" style="width: 0%; height: 100%; background: #4CAF50;"></div>
+    </div>
+    
+    <script>
+        const uploader = new Resumable({
+            target: '/media/chunk',
+            chunkSize: 2 * 1024 * 1024, // 2MB chunks
+            simultaneousUploads: 3,
+            testChunks: true,
+            query: {
+                handler: 'chunked',
+                _action: 'upload'
+            },
+            headers: {
+                'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').getAttribute('content')
+            }
+        });
+        
+        uploader.on('fileAdded', function(file) {
+            console.log('File added:', file.fileName);
+            uploader.upload();
+        });
+        
+        uploader.on('fileProgress', function(file) {
+            const progress = Math.floor(file.progress() * 100);
+            document.getElementById('progress-fill').style.width = progress + '%';
+        });
+        
+        uploader.on('fileSuccess', function(file, response) {
+            console.log('Upload successful:', response);
+            const data = JSON.parse(response);
+            if (data.success && data.files) {
+                console.log('Media saved:', data.files[0]);
+            }
+        });
+        
+        uploader.on('fileError', function(file, message) {
+            console.error('Upload failed:', message);
+        });
+        
+        // Handle file input
+        document.getElementById('file-input').addEventListener('change', function(e) {
+            uploader.addFiles(e.target.files);
+        });
+        
+        // Handle drag and drop
+        const dropZone = document.getElementById('drop-zone');
+        dropZone.addEventListener('dragover', function(e) {
+            e.preventDefault();
+        });
+        
+        dropZone.addEventListener('drop', function(e) {
+            e.preventDefault();
+            uploader.addFiles(e.dataTransfer.files);
+        });
+    </script>
+</body>
+</html>
+```
+
+#### 2. FilePond
+
+```html
+<!DOCTYPE html>
+<html>
+<head>
+    <meta name="csrf-token" content="{{ csrf_token() }}">
+    <link href="https://unpkg.com/filepond/dist/filepond.min.css" rel="stylesheet">
+    <script src="https://unpkg.com/filepond/dist/filepond.min.js"></script>
+    <script src="https://unpkg.com/filepond-plugin-chunk-upload/dist/filepond-plugin-chunk-upload.min.js"></script>
+</head>
+<body>
+    <input type="file" id="filepond-upload" multiple>
+    
+    <script>
+        // Register FilePond plugin
+        FilePond.registerPlugin(FilePondPluginChunkUpload);
+        
+        // Create FilePond instance
+        const pond = FilePond.create(document.getElementById('filepond-upload'), {
+            chunkUploads: true,
+            chunkForce: true,
+            chunkSize: 2 * 1024 * 1024, // 2MB chunks
+            chunkRetryDelays: [0, 1000, 3000, 5000],
+            maxFileSize: '100MB',
+            acceptedFileTypes: ['image/*', 'video/*', 'application/pdf'],
+            
+            server: {
+                url: '/media',
+                process: {
+                    url: '/chunk',
+                    method: 'POST',
+                    headers: {
+                        'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').getAttribute('content')
+                    },
+                    onload: (response) => {
+                        const data = JSON.parse(response);
+                        if (data.success) {
+                            return data.chunk || 'chunk-uploaded';
+                        } else {
+                            throw new Error(data.message || 'Upload failed');
+                        }
+                    }
+                }
+            },
+            
+            onaddfile: (error, file) => {
+                if (error) {
+                    console.error('Error adding file:', error);
+                    return;
+                }
+                console.log('File added:', file.filename);
+            },
+            
+            onprocessfile: (error, file) => {
+                if (error) {
+                    console.error('Error processing file:', error);
+                    return;
+                }
+                console.log('File processed successfully:', file.filename);
+            }
+        });
+    </script>
+</body>
+</html>
+```
+
+## Konfigurasi
+
+### Chunk Size
+
+Rekomendasi chunk size:
+- **1-2MB**: Aman untuk sebagian besar server
+- **5MB**: Untuk server dengan konfigurasi yang lebih baik
+- **10MB+**: Hanya untuk server dengan limit yang tinggi
+
+### Validasi File
+
+```php
+// Di ChunkedMediaHandler, tambahkan validasi sesuai kebutuhan
+protected function validateFile($file)
+{
+    // Validasi ukuran total
+    $maxSize = 100 * 1024 * 1024; // 100MB
+    if ($file->getSize() > $maxSize) {
+        throw new \Exception('File too large');
+    }
+    
+    // Validasi tipe file
+    $allowedTypes = ['image/jpeg', 'image/png', 'video/mp4'];
+    if (!in_array($file->getMimeType(), $allowedTypes)) {
+        throw new \Exception('File type not allowed');
+    }
+}
+```
+
+### Rate Limiting
+
+Tambahkan rate limiting untuk endpoint chunk:
+
+```php
+// Di routes/web.php
+Route::post('chunk', [MediaController::class, 'store'])
+    ->name('chunk.upload')
+    ->middleware('throttle:60,1') // 60 requests per minute
+    ->withoutMiddleware('auth');
+```
+
+## Troubleshooting
+
+### Error 413 Payload Too Large
+
+Jika masih mendapat error 413:
+1. Pastikan chunk size tidak terlalu besar (maksimal 2MB)
+2. Periksa konfigurasi nginx/Apache
+3. Pastikan `upload_max_filesize` dan `post_max_size` di PHP cukup besar
+
+### Chunk Tidak Tersimpan
+
+1. Pastikan direktori `storage/app/chunks` dapat ditulis
+2. Periksa permission direktori storage
+3. Pastikan disk `local` tersedia
+
+### Upload Terputus
+
+1. Pastikan `testChunks: true` di Resumable.js
+2. Implementasikan retry logic di frontend
+3. Periksa network timeout
+
+## Testing
+
+Jalankan test untuk memastikan chunked upload berfungsi:
+
+```bash
+php artisan test packages/media/tests/ChunkedMediaHandlerTest.php
+```
+
+## Migration dari Handler Lama
+
+Untuk migrasi dari `FileuploaderMediaHandler` atau `RedactorMediaHandler`:
+
+1. Ganti endpoint dari `/media/media` ke `/media/chunk`
+2. Tambahkan parameter `handler: 'chunked'`
+3. Implementasikan chunking di frontend
+4. Update error handling untuk response format yang sama
+
+## Keamanan
+
+- ✅ CSRF protection otomatis
+- ✅ Validasi file type dan size
+- ✅ Rate limiting (opsional)
+- ✅ Cleanup otomatis chunk sementara
+- ✅ Dukungan Guest upload yang aman
+
+## Performa
+
+- ✅ Upload paralel dengan `simultaneousUploads`
+- ✅ Resume upload yang terputus
+- ✅ Progress tracking real-time
+- ✅ Cleanup otomatis untuk menghemat storage
+
+## Contoh Lengkap
+
+Lihat file `resources/views/chunked-upload-example.blade.php` untuk contoh implementasi lengkap dengan kedua opsi frontend.

--- a/packages/media/README.md
+++ b/packages/media/README.md
@@ -1,0 +1,308 @@
+# Laravolt Media Package
+
+Package media management untuk Laravolt Platform dengan dukungan upload file besar melalui chunked upload.
+
+## Fitur
+
+- ✅ **Multiple Media Handlers**: Redactor, Fileuploader, dan Chunked
+- ✅ **Chunked Upload**: Upload file besar tanpa mengubah konfigurasi server
+- ✅ **Spatie Media Library Integration**: Integrasi penuh dengan Spatie Media Library
+- ✅ **Guest Upload Support**: Dukungan upload untuk user tidak terautentikasi
+- ✅ **Frontend Options**: Resumable.js dan FilePond
+- ✅ **Automatic Cleanup**: Cleanup otomatis chunk sementara
+- ✅ **Configurable**: Konfigurasi lengkap untuk berbagai kebutuhan
+
+## Instalasi
+
+### 1. Install Dependencies
+
+```bash
+composer require laravolt/laravolt
+composer require pion/laravel-chunk-upload
+```
+
+### 2. Publish Konfigurasi (Opsional)
+
+```bash
+php artisan vendor:publish --tag=chunked-upload-config
+```
+
+### 3. Setup Cleanup Job (Opsional)
+
+Tambahkan ke `app/Console/Kernel.php`:
+
+```php
+protected function schedule(Schedule $schedule)
+{
+    // Cleanup chunk files older than 24 hours
+    $schedule->job(new \Laravolt\Media\Jobs\CleanupChunksJob(24))->daily();
+}
+```
+
+## Penggunaan
+
+### Media Handlers
+
+Package ini menyediakan tiga media handler:
+
+#### 1. RedactorMediaHandler (Default)
+Untuk editor Redactor, mendukung multiple file upload.
+
+```php
+// Endpoint: POST /media/media
+// Parameters: handler=redactor, file[]=files
+```
+
+#### 2. FileuploaderMediaHandler
+Untuk fileuploader.js, mendukung single file upload dengan progress.
+
+```php
+// Endpoint: POST /media/media
+// Parameters: handler=fileuploader, _key=file, _action=upload
+```
+
+#### 3. ChunkedMediaHandler (New!)
+Untuk upload file besar dengan chunking.
+
+```php
+// Endpoint: POST /media/chunk
+// Parameters: handler=chunked, _action=upload, file=chunk
+```
+
+### Chunked Upload
+
+#### Backend API
+
+**Upload Chunk:**
+```http
+POST /media/chunk
+Content-Type: multipart/form-data
+
+file: [chunk file]
+handler: chunked
+_action: upload
+```
+
+**Complete Upload:**
+```http
+POST /media/chunk/complete
+Content-Type: application/json
+
+{
+    "handler": "chunked",
+    "_action": "complete",
+    "file_id": "unique-file-id",
+    "file_name": "original-filename.ext"
+}
+```
+
+**Delete Media:**
+```http
+POST /media/chunk
+Content-Type: application/json
+
+{
+    "handler": "chunked",
+    "_action": "delete",
+    "id": 123
+}
+```
+
+#### Frontend Implementation
+
+**Resumable.js:**
+```javascript
+const uploader = new Resumable({
+    target: '/media/chunk',
+    chunkSize: 2 * 1024 * 1024, // 2MB chunks
+    query: {
+        handler: 'chunked',
+        _action: 'upload'
+    }
+});
+
+uploader.on('fileAdded', function(file) {
+    uploader.upload();
+});
+```
+
+**FilePond:**
+```javascript
+FilePond.registerPlugin(FilePondPluginChunkUpload);
+
+const pond = FilePond.create(document.getElementById('filepond-upload'), {
+    chunkUploads: true,
+    chunkSize: 2 * 1024 * 1024,
+    server: {
+        url: '/media',
+        process: {
+            url: '/chunk',
+            method: 'POST'
+        }
+    }
+});
+```
+
+## Konfigurasi
+
+### Chunked Upload Configuration
+
+File: `config/chunked-upload.php`
+
+```php
+return [
+    'chunk_size' => 2 * 1024 * 1024, // 2MB
+    'max_file_size' => 100 * 1024 * 1024, // 100MB
+    'allowed_types' => [
+        'image/jpeg',
+        'image/png',
+        'video/mp4',
+        'application/pdf'
+    ],
+    'cleanup' => [
+        'enabled' => true,
+        'max_age_hours' => 24
+    ]
+];
+```
+
+### Environment Variables
+
+```env
+# Chunked Upload Configuration
+CHUNKED_UPLOAD_CHUNK_SIZE=2097152
+CHUNKED_UPLOAD_MAX_FILE_SIZE=104857600
+CHUNKED_UPLOAD_CLEANUP_ENABLED=true
+CHUNKED_UPLOAD_CLEANUP_MAX_AGE=24
+```
+
+## Commands
+
+### Cleanup Chunks
+
+```bash
+# Cleanup chunks older than 24 hours
+php artisan media:cleanup-chunks
+
+# Cleanup chunks older than 48 hours
+php artisan media:cleanup-chunks --max-age=48
+
+# Dry run (show what would be deleted)
+php artisan media:cleanup-chunks --dry-run
+```
+
+## Testing
+
+```bash
+# Run all tests
+php artisan test packages/media/tests/
+
+# Run specific test
+php artisan test packages/media/tests/ChunkedMediaHandlerTest.php
+```
+
+## Examples
+
+Lihat file berikut untuk contoh implementasi:
+
+- `resources/views/chunked-upload-example.blade.php` - Contoh HTML lengkap
+- `resources/js/chunked-upload-resumable.js` - Implementasi Resumable.js
+- `resources/js/chunked-upload-filepond.js` - Implementasi FilePond
+- `examples/ChunkedUploadIntegration.php` - Contoh integrasi Laravel
+
+## Troubleshooting
+
+### Error 413 Payload Too Large
+
+1. Pastikan chunk size tidak terlalu besar (maksimal 2MB)
+2. Periksa konfigurasi nginx/Apache
+3. Pastikan `upload_max_filesize` dan `post_max_size` di PHP cukup besar
+
+### Chunk Tidak Tersimpan
+
+1. Pastikan direktori `storage/app/chunks` dapat ditulis
+2. Periksa permission direktori storage
+3. Pastikan disk `local` tersedia
+
+### Upload Terputus
+
+1. Pastikan `testChunks: true` di Resumable.js
+2. Implementasikan retry logic di frontend
+3. Periksa network timeout
+
+## Migration Guide
+
+### Dari Handler Lama
+
+1. **Ganti Endpoint:**
+   ```javascript
+   // Lama
+   target: '/media/media'
+   
+   // Baru
+   target: '/media/chunk'
+   ```
+
+2. **Tambahkan Parameter:**
+   ```javascript
+   query: {
+       handler: 'chunked',
+       _action: 'upload'
+   }
+   ```
+
+3. **Update Error Handling:**
+   ```javascript
+   // Response format tetap sama
+   {
+       "success": true,
+       "files": [...]
+   }
+   ```
+
+### Upgrade dari Laravolt Lama
+
+1. Install dependency baru:
+   ```bash
+   composer require pion/laravel-chunk-upload
+   ```
+
+2. Publish konfigurasi:
+   ```bash
+   php artisan vendor:publish --tag=chunked-upload-config
+   ```
+
+3. Update frontend untuk menggunakan chunked upload
+
+## Security
+
+- ✅ CSRF protection otomatis
+- ✅ Validasi file type dan size
+- ✅ Rate limiting (opsional)
+- ✅ Cleanup otomatis chunk sementara
+- ✅ Dukungan Guest upload yang aman
+
+## Performance
+
+- ✅ Upload paralel dengan `simultaneousUploads`
+- ✅ Resume upload yang terputus
+- ✅ Progress tracking real-time
+- ✅ Cleanup otomatis untuk menghemat storage
+
+## Contributing
+
+1. Fork repository
+2. Create feature branch
+3. Commit changes
+4. Push to branch
+5. Create Pull Request
+
+## License
+
+MIT License. See LICENSE file for details.
+
+## Support
+
+Untuk dukungan dan pertanyaan:
+- GitHub Issues: [Laravolt Repository](https://github.com/laravolt/laravolt)
+- Documentation: [Laravolt Docs](https://laravolt.dev)

--- a/packages/media/config/chunked-upload.php
+++ b/packages/media/config/chunked-upload.php
@@ -1,0 +1,145 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Chunked Upload Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Configuration for chunked file upload functionality
+    |
+    */
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default Chunk Size
+    |--------------------------------------------------------------------------
+    |
+    | Default chunk size in bytes. Recommended: 1-2MB for most servers
+    |
+    */
+    'chunk_size' => env('CHUNKED_UPLOAD_CHUNK_SIZE', 2 * 1024 * 1024), // 2MB
+
+    /*
+    |--------------------------------------------------------------------------
+    | Maximum File Size
+    |--------------------------------------------------------------------------
+    |
+    | Maximum total file size allowed for chunked uploads
+    |
+    */
+    'max_file_size' => env('CHUNKED_UPLOAD_MAX_FILE_SIZE', 100 * 1024 * 1024), // 100MB
+
+    /*
+    |--------------------------------------------------------------------------
+    | Allowed File Types
+    |--------------------------------------------------------------------------
+    |
+    | MIME types allowed for chunked uploads. Leave empty to allow all types.
+    |
+    */
+    'allowed_types' => [
+        'image/jpeg',
+        'image/png',
+        'image/gif',
+        'image/webp',
+        'video/mp4',
+        'video/avi',
+        'video/mov',
+        'application/pdf',
+        'application/msword',
+        'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        'application/vnd.ms-excel',
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Chunk Storage
+    |--------------------------------------------------------------------------
+    |
+    | Configuration for storing chunks temporarily
+    |
+    */
+    'storage' => [
+        'disk' => env('CHUNKED_UPLOAD_DISK', 'local'),
+        'path' => env('CHUNKED_UPLOAD_PATH', 'chunks'),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Cleanup Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Configuration for automatic cleanup of old chunks
+    |
+    */
+    'cleanup' => [
+        'enabled' => env('CHUNKED_UPLOAD_CLEANUP_ENABLED', true),
+        'max_age_hours' => env('CHUNKED_UPLOAD_CLEANUP_MAX_AGE', 24),
+        'schedule' => env('CHUNKED_UPLOAD_CLEANUP_SCHEDULE', 'daily'),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Rate Limiting
+    |--------------------------------------------------------------------------
+    |
+    | Rate limiting configuration for chunk upload endpoints
+    |
+    */
+    'rate_limit' => [
+        'enabled' => env('CHUNKED_UPLOAD_RATE_LIMIT_ENABLED', true),
+        'max_attempts' => env('CHUNKED_UPLOAD_RATE_LIMIT_MAX_ATTEMPTS', 60),
+        'decay_minutes' => env('CHUNKED_UPLOAD_RATE_LIMIT_DECAY_MINUTES', 1),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Frontend Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Default configuration for frontend implementations
+    |
+    */
+    'frontend' => [
+        'resumable' => [
+            'chunk_size' => env('CHUNKED_UPLOAD_FRONTEND_CHUNK_SIZE', 2 * 1024 * 1024),
+            'simultaneous_uploads' => env('CHUNKED_UPLOAD_SIMULTANEOUS_UPLOADS', 3),
+            'test_chunks' => env('CHUNKED_UPLOAD_TEST_CHUNKS', true),
+        ],
+        'filepond' => [
+            'chunk_size' => env('CHUNKED_UPLOAD_FRONTEND_CHUNK_SIZE', 2 * 1024 * 1024),
+            'chunk_retry_delays' => [0, 1000, 3000, 5000],
+            'max_file_size' => '100MB',
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Security Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Security-related configuration
+    |
+    */
+    'security' => [
+        'validate_file_type' => env('CHUNKED_UPLOAD_VALIDATE_FILE_TYPE', true),
+        'validate_file_size' => env('CHUNKED_UPLOAD_VALIDATE_FILE_SIZE', true),
+        'scan_for_viruses' => env('CHUNKED_UPLOAD_SCAN_VIRUSES', false),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Debug Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Debug and logging configuration
+    |
+    */
+    'debug' => [
+        'enabled' => env('CHUNKED_UPLOAD_DEBUG', false),
+        'log_chunks' => env('CHUNKED_UPLOAD_LOG_CHUNKS', false),
+        'log_errors' => env('CHUNKED_UPLOAD_LOG_ERRORS', true),
+    ],
+];

--- a/packages/media/examples/ChunkedUploadIntegration.php
+++ b/packages/media/examples/ChunkedUploadIntegration.php
@@ -1,0 +1,287 @@
+<?php
+
+/**
+ * Laravolt Chunked Upload Integration Example
+ * 
+ * This file demonstrates how to integrate chunked upload functionality
+ * into your Laravel application using Laravolt's ChunkedMediaHandler.
+ */
+
+namespace Laravolt\Media\Examples;
+
+use Illuminate\Http\Request;
+use Laravolt\Media\MediaHandler\ChunkedMediaHandler;
+
+class ChunkedUploadIntegration
+{
+    /**
+     * Example: Basic chunked upload controller
+     */
+    public function uploadChunk(Request $request)
+    {
+        // Set handler to chunked
+        $request->merge(['handler' => 'chunked']);
+        
+        // Create and execute handler
+        $handler = new ChunkedMediaHandler($request);
+        return $handler();
+    }
+
+    /**
+     * Example: Custom validation before chunked upload
+     */
+    public function uploadChunkWithValidation(Request $request)
+    {
+        // Custom validation
+        $request->validate([
+            'file' => 'required|file|max:102400', // 100MB max
+        ]);
+
+        // Set handler to chunked
+        $request->merge(['handler' => 'chunked']);
+        
+        // Create and execute handler
+        $handler = new ChunkedMediaHandler($request);
+        return $handler();
+    }
+
+    /**
+     * Example: Handle chunked upload with custom response
+     */
+    public function uploadChunkCustomResponse(Request $request)
+    {
+        // Set handler to chunked
+        $request->merge(['handler' => 'chunked']);
+        
+        // Create and execute handler
+        $handler = new ChunkedMediaHandler($request);
+        $response = $handler();
+        
+        // Customize response
+        $data = json_decode($response->getContent(), true);
+        
+        if ($data['success'] && isset($data['files'])) {
+            // Add custom fields to response
+            foreach ($data['files'] as &$file) {
+                $file['uploaded_at'] = now()->toISOString();
+                $file['upload_id'] = uniqid();
+            }
+        }
+        
+        return response()->json($data);
+    }
+
+    /**
+     * Example: Handle chunked upload with user context
+     */
+    public function uploadChunkWithUserContext(Request $request)
+    {
+        // Add user context to request
+        $request->merge([
+            'handler' => 'chunked',
+            'user_id' => auth()->id(),
+            'upload_context' => 'profile_picture'
+        ]);
+        
+        // Create and execute handler
+        $handler = new ChunkedMediaHandler($request);
+        return $handler();
+    }
+
+    /**
+     * Example: Handle chunked upload with progress tracking
+     */
+    public function uploadChunkWithProgress(Request $request)
+    {
+        // Set handler to chunked
+        $request->merge(['handler' => 'chunked']);
+        
+        // Create and execute handler
+        $handler = new ChunkedMediaHandler($request);
+        $response = $handler();
+        
+        // Add progress information to response
+        $data = json_decode($response->getContent(), true);
+        
+        if (isset($data['done'])) {
+            $data['progress_percentage'] = $data['done'];
+            $data['estimated_time_remaining'] = $this->calculateEstimatedTime($data);
+        }
+        
+        return response()->json($data);
+    }
+
+    /**
+     * Example: Handle chunked upload with custom storage
+     */
+    public function uploadChunkWithCustomStorage(Request $request)
+    {
+        // Set handler to chunked
+        $request->merge(['handler' => 'chunked']);
+        
+        // Create and execute handler
+        $handler = new ChunkedMediaHandler($request);
+        $response = $handler();
+        
+        // Custom storage logic after upload
+        $data = json_decode($response->getContent(), true);
+        
+        if ($data['success'] && isset($data['files'])) {
+            foreach ($data['files'] as $file) {
+                // Store additional metadata
+                $this->storeUploadMetadata($file);
+                
+                // Trigger custom events
+                event(new \App\Events\FileUploaded($file));
+            }
+        }
+        
+        return $response;
+    }
+
+    /**
+     * Example: Handle chunked upload with error handling
+     */
+    public function uploadChunkWithErrorHandling(Request $request)
+    {
+        try {
+            // Set handler to chunked
+            $request->merge(['handler' => 'chunked']);
+            
+            // Create and execute handler
+            $handler = new ChunkedMediaHandler($request);
+            $response = $handler();
+            
+            return $response;
+            
+        } catch (\Exception $e) {
+            // Log error
+            \Log::error('Chunked upload failed: ' . $e->getMessage(), [
+                'user_id' => auth()->id(),
+                'file_name' => $request->file('file')?->getClientOriginalName(),
+                'file_size' => $request->file('file')?->getSize(),
+            ]);
+            
+            // Return error response
+            return response()->json([
+                'success' => false,
+                'message' => 'Upload failed. Please try again.',
+                'error_code' => 'UPLOAD_FAILED'
+            ], 500);
+        }
+    }
+
+    /**
+     * Example: Handle chunked upload with rate limiting
+     */
+    public function uploadChunkWithRateLimit(Request $request)
+    {
+        // Check rate limit
+        $key = 'chunked_upload:' . auth()->id();
+        $maxAttempts = 10; // 10 uploads per minute
+        $decayMinutes = 1;
+        
+        if (\RateLimiter::tooManyAttempts($key, $maxAttempts)) {
+            $seconds = \RateLimiter::availableIn($key);
+            return response()->json([
+                'success' => false,
+                'message' => "Too many upload attempts. Please wait {$seconds} seconds.",
+                'retry_after' => $seconds
+            ], 429);
+        }
+        
+        // Increment rate limit
+        \RateLimiter::hit($key, $decayMinutes * 60);
+        
+        // Set handler to chunked
+        $request->merge(['handler' => 'chunked']);
+        
+        // Create and execute handler
+        $handler = new ChunkedMediaHandler($request);
+        return $handler();
+    }
+
+    /**
+     * Example: Handle chunked upload with custom middleware
+     */
+    public function uploadChunkWithMiddleware(Request $request)
+    {
+        // Apply custom middleware logic
+        if (!$this->canUploadFile($request)) {
+            return response()->json([
+                'success' => false,
+                'message' => 'You are not allowed to upload files.',
+                'error_code' => 'UPLOAD_NOT_ALLOWED'
+            ], 403);
+        }
+        
+        // Set handler to chunked
+        $request->merge(['handler' => 'chunked']);
+        
+        // Create and execute handler
+        $handler = new ChunkedMediaHandler($request);
+        return $handler();
+    }
+
+    /**
+     * Helper method: Calculate estimated time remaining
+     */
+    private function calculateEstimatedTime(array $data): ?int
+    {
+        if (!isset($data['done']) || $data['done'] <= 0) {
+            return null;
+        }
+        
+        $progress = $data['done'] / 100;
+        $elapsedTime = time() - ($data['start_time'] ?? time());
+        $totalEstimatedTime = $elapsedTime / $progress;
+        $remainingTime = $totalEstimatedTime - $elapsedTime;
+        
+        return max(0, (int) $remainingTime);
+    }
+
+    /**
+     * Helper method: Store upload metadata
+     */
+    private function storeUploadMetadata(array $file): void
+    {
+        // Store additional metadata in database
+        \DB::table('upload_metadata')->insert([
+            'media_id' => $file['data']['id'],
+            'user_id' => auth()->id(),
+            'original_name' => $file['name'],
+            'file_size' => $file['size'],
+            'mime_type' => $file['type'],
+            'uploaded_at' => now(),
+        ]);
+    }
+
+    /**
+     * Helper method: Check if user can upload file
+     */
+    private function canUploadFile(Request $request): bool
+    {
+        // Custom logic to check if user can upload
+        $user = auth()->user();
+        
+        if (!$user) {
+            return false;
+        }
+        
+        // Check user permissions
+        if (!$user->can('upload_files')) {
+            return false;
+        }
+        
+        // Check file type restrictions
+        $file = $request->file('file');
+        if ($file) {
+            $allowedTypes = ['image/jpeg', 'image/png', 'application/pdf'];
+            if (!in_array($file->getMimeType(), $allowedTypes)) {
+                return false;
+            }
+        }
+        
+        return true;
+    }
+}

--- a/packages/media/resources/js/chunked-upload-filepond.js
+++ b/packages/media/resources/js/chunked-upload-filepond.js
@@ -1,0 +1,230 @@
+/**
+ * Laravolt Chunked Upload with FilePond
+ * 
+ * Example implementation for chunked file upload using FilePond
+ * Compatible with Laravolt's ChunkedMediaHandler
+ */
+
+// Import FilePond and plugins
+import { create, registerPlugin } from 'filepond';
+import FilePondPluginFileValidateType from 'filepond-plugin-file-validate-type';
+import FilePondPluginFileValidateSize from 'filepond-plugin-file-validate-size';
+import FilePondPluginChunkUpload from 'filepond-plugin-chunk-upload';
+
+// Register plugins
+registerPlugin(
+    FilePondPluginFileValidateType,
+    FilePondPluginFileValidateSize,
+    FilePondPluginChunkUpload
+);
+
+class LaravoltFilePondUpload {
+    constructor(element, options = {}) {
+        this.options = {
+            chunkSize: 2 * 1024 * 1024, // 2MB chunks
+            chunkUploads: true,
+            chunkForce: true,
+            chunkRetryDelays: [0, 1000, 3000, 5000],
+            maxFileSize: '100MB',
+            acceptedFileTypes: ['image/*', 'video/*', 'application/pdf'],
+            ...options
+        };
+
+        this.pond = this.createPond(element);
+    }
+
+    createPond(element) {
+        return create(element, {
+            // Chunk upload configuration
+            chunkUploads: this.options.chunkUploads,
+            chunkForce: this.options.chunkForce,
+            chunkSize: this.options.chunkSize,
+            chunkRetryDelays: this.options.chunkRetryDelays,
+
+            // Server configuration
+            server: {
+                url: '/media',
+                process: {
+                    url: '/chunk',
+                    method: 'POST',
+                    headers: {
+                        'X-CSRF-TOKEN': this.getCsrfToken()
+                    },
+                    onload: (response) => {
+                        // Handle chunk upload response
+                        try {
+                            const data = JSON.parse(response);
+                            if (data.success) {
+                                return data.chunk || 'chunk-uploaded';
+                            } else {
+                                throw new Error(data.message || 'Upload failed');
+                            }
+                        } catch (e) {
+                            throw new Error('Invalid response format');
+                        }
+                    },
+                    onerror: (response) => {
+                        throw new Error('Upload failed');
+                    }
+                },
+                revert: {
+                    url: '/media/chunk',
+                    method: 'DELETE',
+                    headers: {
+                        'X-CSRF-TOKEN': this.getCsrfToken()
+                    }
+                },
+                restore: {
+                    url: '/media/chunk/restore',
+                    method: 'POST',
+                    headers: {
+                        'X-CSRF-TOKEN': this.getCsrfToken()
+                    }
+                },
+                load: {
+                    url: '/media/',
+                    method: 'GET'
+                }
+            },
+
+            // File validation
+            maxFileSize: this.options.maxFileSize,
+            acceptedFileTypes: this.options.acceptedFileTypes,
+
+            // Event handlers
+            onaddfile: (error, file) => {
+                if (error) {
+                    console.error('Error adding file:', error);
+                    return;
+                }
+                console.log('File added:', file.filename);
+                if (this.options.onFileAdded) {
+                    this.options.onFileAdded(file);
+                }
+            },
+
+            onprocessfile: (error, file) => {
+                if (error) {
+                    console.error('Error processing file:', error);
+                    if (this.options.onError) {
+                        this.options.onError(file, error);
+                    }
+                    return;
+                }
+                console.log('File processed successfully:', file.filename);
+                if (this.options.onSuccess) {
+                    this.options.onSuccess(file);
+                }
+            },
+
+            onprocessfiles: () => {
+                console.log('All files processed');
+                if (this.options.onComplete) {
+                    this.options.onComplete();
+                }
+            },
+
+            onupdatefiles: (files) => {
+                console.log('Files updated:', files.length);
+                if (this.options.onFilesUpdate) {
+                    this.options.onFilesUpdate(files);
+                }
+            }
+        });
+    }
+
+    /**
+     * Get CSRF token
+     */
+    getCsrfToken() {
+        const token = document.querySelector('meta[name="csrf-token"]');
+        return token ? token.getAttribute('content') : '';
+    }
+
+    /**
+     * Destroy FilePond instance
+     */
+    destroy() {
+        this.pond.destroy();
+    }
+
+    /**
+     * Get files
+     */
+    getFiles() {
+        return this.pond.getFiles();
+    }
+
+    /**
+     * Add files
+     */
+    addFiles(files) {
+        this.pond.addFiles(files);
+    }
+
+    /**
+     * Remove all files
+     */
+    removeFiles() {
+        this.pond.removeFiles();
+    }
+}
+
+// Example usage
+document.addEventListener('DOMContentLoaded', function() {
+    // Create FilePond instance
+    const filePondUpload = new LaravoltFilePondUpload('#filepond-upload', {
+        chunkSize: 2 * 1024 * 1024, // 2MB chunks
+        maxFileSize: '100MB',
+        acceptedFileTypes: ['image/*', 'video/*', 'application/pdf'],
+        
+        onFileAdded: function(file) {
+            console.log('File added:', file.filename);
+            // Update UI
+        },
+        
+        onSuccess: function(file) {
+            console.log('File uploaded successfully:', file.filename);
+            // Handle successful upload
+            const serverId = file.serverId;
+            console.log('Server ID:', serverId);
+        },
+        
+        onError: function(file, error) {
+            console.error('Upload error:', error);
+            // Show error message
+        },
+        
+        onComplete: function() {
+            console.log('All uploads completed');
+            // Reset UI or show completion message
+        },
+        
+        onFilesUpdate: function(files) {
+            console.log('Files updated:', files.length);
+            // Update file list UI
+        }
+    });
+
+    // Example: Get uploaded files
+    const getUploadedFiles = () => {
+        const files = filePondUpload.getFiles();
+        const uploadedFiles = files.filter(file => file.status === 5); // FilePond.FileStatus.PROCESSING_COMPLETE
+        console.log('Uploaded files:', uploadedFiles);
+        return uploadedFiles;
+    };
+
+    // Example: Handle form submission
+    const form = document.getElementById('upload-form');
+    if (form) {
+        form.addEventListener('submit', function(e) {
+            e.preventDefault();
+            const uploadedFiles = getUploadedFiles();
+            console.log('Submitting form with files:', uploadedFiles);
+            // Submit form with file IDs
+        });
+    }
+});
+
+// Export for module usage
+export default LaravoltFilePondUpload;

--- a/packages/media/resources/js/chunked-upload-resumable.js
+++ b/packages/media/resources/js/chunked-upload-resumable.js
@@ -1,0 +1,205 @@
+/**
+ * Laravolt Chunked Upload with Resumable.js
+ * 
+ * Example implementation for chunked file upload using Resumable.js
+ * Compatible with Laravolt's ChunkedMediaHandler
+ */
+
+class LaravoltChunkedUpload {
+    constructor(options = {}) {
+        this.options = {
+            chunkSize: 2 * 1024 * 1024, // 2MB chunks
+            simultaneousUploads: 3,
+            testChunks: true,
+            throttleProgressCallbacks: 1,
+            method: 'POST',
+            uploadMethod: 'POST',
+            ...options
+        };
+
+        this.resumable = null;
+        this.initializeResumable();
+    }
+
+    initializeResumable() {
+        this.resumable = new Resumable({
+            target: this.options.target || '/media/chunk',
+            chunkSize: this.options.chunkSize,
+            simultaneousUploads: this.options.simultaneousUploads,
+            testChunks: this.options.testChunks,
+            throttleProgressCallbacks: this.options.throttleProgressCallbacks,
+            method: this.options.method,
+            uploadMethod: this.options.uploadMethod,
+            query: {
+                handler: 'chunked',
+                _action: 'upload'
+            },
+            headers: {
+                'X-CSRF-TOKEN': this.getCsrfToken()
+            }
+        });
+
+        this.setupEventHandlers();
+    }
+
+    setupEventHandlers() {
+        // File added
+        this.resumable.on('fileAdded', (file) => {
+            console.log('File added:', file.fileName);
+            if (this.options.onFileAdded) {
+                this.options.onFileAdded(file);
+            }
+        });
+
+        // File progress
+        this.resumable.on('fileProgress', (file) => {
+            const progress = Math.floor(file.progress() * 100);
+            console.log('Upload progress:', progress + '%');
+            if (this.options.onProgress) {
+                this.options.onProgress(file, progress);
+            }
+        });
+
+        // File success
+        this.resumable.on('fileSuccess', (file, response) => {
+            console.log('File uploaded successfully:', file.fileName);
+            try {
+                const data = JSON.parse(response);
+                if (this.options.onSuccess) {
+                    this.options.onSuccess(file, data);
+                }
+            } catch (e) {
+                console.error('Error parsing response:', e);
+                if (this.options.onError) {
+                    this.options.onError(file, 'Invalid response format');
+                }
+            }
+        });
+
+        // File error
+        this.resumable.on('fileError', (file, message) => {
+            console.error('Upload error:', message);
+            if (this.options.onError) {
+                this.options.onError(file, message);
+            }
+        });
+
+        // Upload complete
+        this.resumable.on('complete', () => {
+            console.log('All files uploaded');
+            if (this.options.onComplete) {
+                this.options.onComplete();
+            }
+        });
+    }
+
+    /**
+     * Add files to upload queue
+     */
+    addFiles(files) {
+        this.resumable.addFiles(files);
+    }
+
+    /**
+     * Start upload
+     */
+    upload() {
+        this.resumable.upload();
+    }
+
+    /**
+     * Pause upload
+     */
+    pause() {
+        this.resumable.pause();
+    }
+
+    /**
+     * Resume upload
+     */
+    resume() {
+        this.resumable.upload();
+    }
+
+    /**
+     * Cancel upload
+     */
+    cancel() {
+        this.resumable.cancel();
+    }
+
+    /**
+     * Get CSRF token
+     */
+    getCsrfToken() {
+        const token = document.querySelector('meta[name="csrf-token"]');
+        return token ? token.getAttribute('content') : '';
+    }
+}
+
+// Example usage with HTML form
+document.addEventListener('DOMContentLoaded', function() {
+    const uploader = new LaravoltChunkedUpload({
+        target: '/media/chunk',
+        onFileAdded: function(file) {
+            console.log('File added:', file.fileName);
+            // Update UI to show file is ready for upload
+        },
+        onProgress: function(file, progress) {
+            console.log('Progress:', progress + '%');
+            // Update progress bar
+            const progressBar = document.getElementById('progress-bar');
+            if (progressBar) {
+                progressBar.style.width = progress + '%';
+                progressBar.textContent = progress + '%';
+            }
+        },
+        onSuccess: function(file, response) {
+            console.log('Upload successful:', response);
+            // Handle successful upload
+            if (response.success && response.files && response.files.length > 0) {
+                const media = response.files[0];
+                console.log('Media saved:', media);
+                // Update UI with uploaded media info
+            }
+        },
+        onError: function(file, message) {
+            console.error('Upload failed:', message);
+            // Show error message to user
+        },
+        onComplete: function() {
+            console.log('All uploads completed');
+            // Reset UI or show completion message
+        }
+    });
+
+    // Handle file input change
+    const fileInput = document.getElementById('file-input');
+    if (fileInput) {
+        fileInput.addEventListener('change', function(e) {
+            uploader.addFiles(e.target.files);
+            uploader.upload();
+        });
+    }
+
+    // Handle drag and drop
+    const dropZone = document.getElementById('drop-zone');
+    if (dropZone) {
+        dropZone.addEventListener('dragover', function(e) {
+            e.preventDefault();
+            dropZone.classList.add('dragover');
+        });
+
+        dropZone.addEventListener('dragleave', function(e) {
+            e.preventDefault();
+            dropZone.classList.remove('dragover');
+        });
+
+        dropZone.addEventListener('drop', function(e) {
+            e.preventDefault();
+            dropZone.classList.remove('dragover');
+            uploader.addFiles(e.dataTransfer.files);
+            uploader.upload();
+        });
+    }
+});

--- a/packages/media/resources/views/chunked-upload-example.blade.php
+++ b/packages/media/resources/views/chunked-upload-example.blade.php
@@ -1,0 +1,374 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
+    <title>Laravolt Chunked Upload Example</title>
+    
+    <!-- Resumable.js -->
+    <script src="https://cdn.jsdelivr.net/npm/resumablejs@1.1.0/resumable.min.js"></script>
+    
+    <!-- FilePond -->
+    <link href="https://unpkg.com/filepond/dist/filepond.min.css" rel="stylesheet">
+    <script src="https://unpkg.com/filepond/dist/filepond.min.js"></script>
+    <script src="https://unpkg.com/filepond-plugin-file-validate-type/dist/filepond-plugin-file-validate-type.min.js"></script>
+    <script src="https://unpkg.com/filepond-plugin-file-validate-size/dist/filepond-plugin-file-validate-size.min.js"></script>
+    <script src="https://unpkg.com/filepond-plugin-chunk-upload/dist/filepond-plugin-chunk-upload.min.js"></script>
+    
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 20px;
+        }
+        
+        .upload-section {
+            margin: 20px 0;
+            padding: 20px;
+            border: 1px solid #ddd;
+            border-radius: 8px;
+        }
+        
+        .progress-bar {
+            width: 100%;
+            height: 20px;
+            background-color: #f0f0f0;
+            border-radius: 10px;
+            overflow: hidden;
+            margin: 10px 0;
+        }
+        
+        .progress-fill {
+            height: 100%;
+            background-color: #4CAF50;
+            transition: width 0.3s ease;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            color: white;
+            font-size: 12px;
+        }
+        
+        .drop-zone {
+            border: 2px dashed #ccc;
+            border-radius: 8px;
+            padding: 40px;
+            text-align: center;
+            margin: 20px 0;
+            transition: border-color 0.3s ease;
+        }
+        
+        .drop-zone.dragover {
+            border-color: #4CAF50;
+            background-color: #f9f9f9;
+        }
+        
+        .file-list {
+            margin: 20px 0;
+        }
+        
+        .file-item {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            padding: 10px;
+            border: 1px solid #eee;
+            border-radius: 4px;
+            margin: 5px 0;
+        }
+        
+        .file-info {
+            flex: 1;
+        }
+        
+        .file-status {
+            padding: 4px 8px;
+            border-radius: 4px;
+            font-size: 12px;
+            font-weight: bold;
+        }
+        
+        .status-uploading {
+            background-color: #fff3cd;
+            color: #856404;
+        }
+        
+        .status-success {
+            background-color: #d4edda;
+            color: #155724;
+        }
+        
+        .status-error {
+            background-color: #f8d7da;
+            color: #721c24;
+        }
+        
+        .btn {
+            padding: 10px 20px;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+            font-size: 14px;
+        }
+        
+        .btn-primary {
+            background-color: #007bff;
+            color: white;
+        }
+        
+        .btn-secondary {
+            background-color: #6c757d;
+            color: white;
+        }
+        
+        .btn:hover {
+            opacity: 0.8;
+        }
+    </style>
+</head>
+<body>
+    <h1>Laravolt Chunked Upload Examples</h1>
+    
+    <!-- Resumable.js Example -->
+    <div class="upload-section">
+        <h2>Resumable.js Upload</h2>
+        <p>Upload large files using Resumable.js with chunked upload support.</p>
+        
+        <div class="drop-zone" id="drop-zone">
+            <p>Drag and drop files here or click to select</p>
+            <input type="file" id="file-input" multiple style="display: none;">
+            <button class="btn btn-primary" onclick="document.getElementById('file-input').click()">
+                Select Files
+            </button>
+        </div>
+        
+        <div class="progress-bar" id="progress-container" style="display: none;">
+            <div class="progress-fill" id="progress-bar">0%</div>
+        </div>
+        
+        <div class="file-list" id="file-list"></div>
+        
+        <div>
+            <button class="btn btn-primary" id="start-upload" onclick="startResumableUpload()">Start Upload</button>
+            <button class="btn btn-secondary" id="pause-upload" onclick="pauseResumableUpload()">Pause</button>
+            <button class="btn btn-secondary" id="cancel-upload" onclick="cancelResumableUpload()">Cancel</button>
+        </div>
+    </div>
+    
+    <!-- FilePond Example -->
+    <div class="upload-section">
+        <h2>FilePond Upload</h2>
+        <p>Upload files using FilePond with chunked upload support and better UX.</p>
+        
+        <input type="file" id="filepond-upload" multiple>
+        
+        <div class="file-list" id="filepond-list"></div>
+    </div>
+    
+    <script>
+        // Resumable.js implementation
+        let resumableUploader = null;
+        
+        document.addEventListener('DOMContentLoaded', function() {
+            // Initialize Resumable.js uploader
+            resumableUploader = new LaravoltChunkedUpload({
+                target: '/media/chunk',
+                chunkSize: 2 * 1024 * 1024, // 2MB chunks
+                onFileAdded: function(file) {
+                    addFileToList(file, 'resumable');
+                },
+                onProgress: function(file, progress) {
+                    updateFileProgress(file, progress, 'resumable');
+                },
+                onSuccess: function(file, response) {
+                    updateFileStatus(file, 'success', 'resumable');
+                    if (response.success && response.files && response.files.length > 0) {
+                        const media = response.files[0];
+                        console.log('Media saved:', media);
+                    }
+                },
+                onError: function(file, message) {
+                    updateFileStatus(file, 'error', 'resumable');
+                    console.error('Upload failed:', message);
+                },
+                onComplete: function() {
+                    console.log('All uploads completed');
+                }
+            });
+            
+            // Handle file input change
+            const fileInput = document.getElementById('file-input');
+            fileInput.addEventListener('change', function(e) {
+                resumableUploader.addFiles(e.target.files);
+            });
+            
+            // Handle drag and drop
+            const dropZone = document.getElementById('drop-zone');
+            dropZone.addEventListener('dragover', function(e) {
+                e.preventDefault();
+                dropZone.classList.add('dragover');
+            });
+            
+            dropZone.addEventListener('dragleave', function(e) {
+                e.preventDefault();
+                dropZone.classList.remove('dragover');
+            });
+            
+            dropZone.addEventListener('drop', function(e) {
+                e.preventDefault();
+                dropZone.classList.remove('dragover');
+                resumableUploader.addFiles(e.dataTransfer.files);
+            });
+            
+            // Initialize FilePond
+            initializeFilePond();
+        });
+        
+        function startResumableUpload() {
+            if (resumableUploader) {
+                resumableUploader.upload();
+                document.getElementById('progress-container').style.display = 'block';
+            }
+        }
+        
+        function pauseResumableUpload() {
+            if (resumableUploader) {
+                resumableUploader.pause();
+            }
+        }
+        
+        function cancelResumableUpload() {
+            if (resumableUploader) {
+                resumableUploader.cancel();
+                document.getElementById('progress-container').style.display = 'none';
+            }
+        }
+        
+        function addFileToList(file, type) {
+            const fileList = document.getElementById(type === 'resumable' ? 'file-list' : 'filepond-list');
+            const fileItem = document.createElement('div');
+            fileItem.className = 'file-item';
+            fileItem.id = `file-${type}-${file.uniqueIdentifier || file.id}`;
+            
+            fileItem.innerHTML = `
+                <div class="file-info">
+                    <strong>${file.fileName || file.filename}</strong>
+                    <br>
+                    <small>Size: ${formatFileSize(file.size)}</small>
+                </div>
+                <div class="file-status status-uploading">Uploading...</div>
+            `;
+            
+            fileList.appendChild(fileItem);
+        }
+        
+        function updateFileProgress(file, progress, type) {
+            const fileItem = document.getElementById(`file-${type}-${file.uniqueIdentifier || file.id}`);
+            if (fileItem) {
+                const status = fileItem.querySelector('.file-status');
+                status.textContent = `${progress}%`;
+                status.className = 'file-status status-uploading';
+            }
+            
+            // Update global progress bar for Resumable.js
+            if (type === 'resumable') {
+                const progressBar = document.getElementById('progress-bar');
+                progressBar.style.width = progress + '%';
+                progressBar.textContent = progress + '%';
+            }
+        }
+        
+        function updateFileStatus(file, status, type) {
+            const fileItem = document.getElementById(`file-${type}-${file.uniqueIdentifier || file.id}`);
+            if (fileItem) {
+                const statusElement = fileItem.querySelector('.file-status');
+                statusElement.className = `file-status status-${status}`;
+                
+                switch (status) {
+                    case 'success':
+                        statusElement.textContent = 'Uploaded';
+                        break;
+                    case 'error':
+                        statusElement.textContent = 'Failed';
+                        break;
+                    default:
+                        statusElement.textContent = status;
+                }
+            }
+        }
+        
+        function formatFileSize(bytes) {
+            if (bytes === 0) return '0 Bytes';
+            const k = 1024;
+            const sizes = ['Bytes', 'KB', 'MB', 'GB'];
+            const i = Math.floor(Math.log(bytes) / Math.log(k));
+            return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
+        }
+        
+        // FilePond implementation
+        function initializeFilePond() {
+            // Register FilePond plugins
+            FilePond.registerPlugin(
+                FilePondPluginFileValidateType,
+                FilePondPluginFileValidateSize,
+                FilePondPluginChunkUpload
+            );
+            
+            // Create FilePond instance
+            const pond = FilePond.create(document.getElementById('filepond-upload'), {
+                chunkUploads: true,
+                chunkForce: true,
+                chunkSize: 2 * 1024 * 1024, // 2MB chunks
+                chunkRetryDelays: [0, 1000, 3000, 5000],
+                maxFileSize: '100MB',
+                acceptedFileTypes: ['image/*', 'video/*', 'application/pdf'],
+                
+                server: {
+                    url: '/media',
+                    process: {
+                        url: '/chunk',
+                        method: 'POST',
+                        headers: {
+                            'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').getAttribute('content')
+                        },
+                        onload: (response) => {
+                            try {
+                                const data = JSON.parse(response);
+                                if (data.success) {
+                                    return data.chunk || 'chunk-uploaded';
+                                } else {
+                                    throw new Error(data.message || 'Upload failed');
+                                }
+                            } catch (e) {
+                                throw new Error('Invalid response format');
+                            }
+                        },
+                        onerror: (response) => {
+                            throw new Error('Upload failed');
+                        }
+                    }
+                },
+                
+                onaddfile: (error, file) => {
+                    if (error) {
+                        console.error('Error adding file:', error);
+                        return;
+                    }
+                    addFileToList(file, 'filepond');
+                },
+                
+                onprocessfile: (error, file) => {
+                    if (error) {
+                        console.error('Error processing file:', error);
+                        updateFileStatus(file, 'error', 'filepond');
+                        return;
+                    }
+                    updateFileStatus(file, 'success', 'filepond');
+                }
+            });
+        }
+    </script>
+</body>
+</html>

--- a/packages/media/routes/web.php
+++ b/packages/media/routes/web.php
@@ -19,5 +19,14 @@ Route::group(
         Route::get('stream/{media}', \Laravolt\Media\Controllers\VideoStreamController::class)
             ->withoutMiddleware('auth')
             ->name('stream');
+
+        // Chunked upload routes
+        Route::post('chunk', [\Laravolt\Media\Controllers\MediaController::class, 'store'])
+            ->name('chunk.upload')
+            ->withoutMiddleware('auth');
+
+        Route::post('chunk/complete', [\Laravolt\Media\Controllers\MediaController::class, 'store'])
+            ->name('chunk.complete')
+            ->withoutMiddleware('auth');
     }
 );

--- a/packages/media/src/Commands/CleanupChunksCommand.php
+++ b/packages/media/src/Commands/CleanupChunksCommand.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravolt\Media\Commands;
+
+use Illuminate\Console\Command;
+use Laravolt\Media\Jobs\CleanupChunksJob;
+
+class CleanupChunksCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     */
+    protected $signature = 'media:cleanup-chunks 
+                            {--max-age=24 : Maximum age of chunks in hours}
+                            {--dry-run : Show what would be deleted without actually deleting}';
+
+    /**
+     * The console command description.
+     */
+    protected $description = 'Clean up old chunk files from chunked uploads';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        $maxAge = (int) $this->option('max-age');
+        $dryRun = $this->option('dry-run');
+
+        $this->info("Cleaning up chunks older than {$maxAge} hours...");
+
+        if ($dryRun) {
+            $this->info('DRY RUN MODE - No files will be deleted');
+            $this->performCleanup($maxAge, true);
+        } else {
+            $this->performCleanup($maxAge, false);
+        }
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * Perform the cleanup operation
+     */
+    protected function performCleanup(int $maxAgeHours, bool $dryRun): void
+    {
+        $chunksPath = storage_path('app/chunks');
+        
+        if (!is_dir($chunksPath)) {
+            $this->info('No chunks directory found.');
+            return;
+        }
+
+        $maxAge = $maxAgeHours * 3600; // Convert hours to seconds
+        $deletedCount = 0;
+        $deletedSize = 0;
+
+        $this->cleanupDirectory($chunksPath, $maxAge, $dryRun, $deletedCount, $deletedSize);
+
+        if ($dryRun) {
+            $this->info("Would delete {$deletedCount} files/directories");
+            $this->info("Would free up " . $this->formatBytes($deletedSize) . " of space");
+        } else {
+            $this->info("Deleted {$deletedCount} files/directories");
+            $this->info("Freed up " . $this->formatBytes($deletedSize) . " of space");
+        }
+    }
+
+    /**
+     * Recursively cleanup directory
+     */
+    protected function cleanupDirectory(string $dir, int $maxAge, bool $dryRun, int &$deletedCount, int &$deletedSize): void
+    {
+        $files = array_diff(scandir($dir), ['.', '..']);
+        
+        foreach ($files as $file) {
+            $path = $dir . DIRECTORY_SEPARATOR . $file;
+            
+            if (is_dir($path)) {
+                // Check if directory is older than max age
+                if ($this->isDirectoryOld($path, $maxAge)) {
+                    $size = $this->getDirectorySize($path);
+                    $deletedSize += $size;
+                    $deletedCount++;
+                    
+                    if ($dryRun) {
+                        $this->line("Would delete directory: {$path} (" . $this->formatBytes($size) . ")");
+                    } else {
+                        $this->deleteDirectory($path);
+                        $this->line("Deleted directory: {$path} (" . $this->formatBytes($size) . ")");
+                    }
+                } else {
+                    // Recursively check subdirectories
+                    $this->cleanupDirectory($path, $maxAge, $dryRun, $deletedCount, $deletedSize);
+                }
+            }
+        }
+    }
+
+    /**
+     * Check if directory is older than max age
+     */
+    protected function isDirectoryOld(string $path, int $maxAge): bool
+    {
+        $directoryTime = filemtime($path);
+        return (time() - $directoryTime) > $maxAge;
+    }
+
+    /**
+     * Get directory size recursively
+     */
+    protected function getDirectorySize(string $dir): int
+    {
+        $size = 0;
+        
+        if (is_dir($dir)) {
+            $files = array_diff(scandir($dir), ['.', '..']);
+            foreach ($files as $file) {
+                $path = $dir . DIRECTORY_SEPARATOR . $file;
+                if (is_dir($path)) {
+                    $size += $this->getDirectorySize($path);
+                } else {
+                    $size += filesize($path);
+                }
+            }
+        }
+        
+        return $size;
+    }
+
+    /**
+     * Recursively delete directory
+     */
+    protected function deleteDirectory(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        $files = array_diff(scandir($dir), ['.', '..']);
+        foreach ($files as $file) {
+            $path = $dir . DIRECTORY_SEPARATOR . $file;
+            is_dir($path) ? $this->deleteDirectory($path) : unlink($path);
+        }
+        rmdir($dir);
+    }
+
+    /**
+     * Format bytes to human readable format
+     */
+    protected function formatBytes(int $bytes): string
+    {
+        if ($bytes === 0) {
+            return '0 Bytes';
+        }
+        
+        $k = 1024;
+        $sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB'];
+        $i = floor(log($bytes) / log($k));
+        
+        return round($bytes / pow($k, $i), 2) . ' ' . $sizes[$i];
+    }
+}

--- a/packages/media/src/Controllers/MediaController.php
+++ b/packages/media/src/Controllers/MediaController.php
@@ -3,6 +3,7 @@
 namespace Laravolt\Media\Controllers;
 
 use Illuminate\Routing\Controller;
+use Laravolt\Media\MediaHandler\ChunkedMediaHandler;
 use Laravolt\Media\MediaHandler\FileuploaderMediaHandler;
 use Laravolt\Media\MediaHandler\RedactorMediaHandler;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
@@ -14,6 +15,9 @@ class MediaController extends Controller
         switch (request('handler')) {
             case 'fileuploader':
                 $handler = new FileuploaderMediaHandler;
+                break;
+            case 'chunked':
+                $handler = new ChunkedMediaHandler;
                 break;
             case 'redactor':
             default:

--- a/packages/media/src/Jobs/CleanupChunksJob.php
+++ b/packages/media/src/Jobs/CleanupChunksJob.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravolt\Media\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Storage;
+
+class CleanupChunksJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    protected int $maxAgeHours;
+
+    public function __construct(int $maxAgeHours = 24)
+    {
+        $this->maxAgeHours = $maxAgeHours;
+    }
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        $chunksPath = storage_path('app/chunks');
+        
+        if (!is_dir($chunksPath)) {
+            return;
+        }
+
+        $this->cleanupDirectory($chunksPath);
+    }
+
+    /**
+     * Recursively cleanup old chunk directories
+     */
+    protected function cleanupDirectory(string $dir): void
+    {
+        $files = array_diff(scandir($dir), ['.', '..']);
+        
+        foreach ($files as $file) {
+            $path = $dir . DIRECTORY_SEPARATOR . $file;
+            
+            if (is_dir($path)) {
+                // Check if directory is older than max age
+                if ($this->isDirectoryOld($path)) {
+                    $this->deleteDirectory($path);
+                } else {
+                    // Recursively check subdirectories
+                    $this->cleanupDirectory($path);
+                }
+            }
+        }
+    }
+
+    /**
+     * Check if directory is older than max age
+     */
+    protected function isDirectoryOld(string $path): bool
+    {
+        $maxAge = $this->maxAgeHours * 3600; // Convert hours to seconds
+        $directoryTime = filemtime($path);
+        
+        return (time() - $directoryTime) > $maxAge;
+    }
+
+    /**
+     * Recursively delete directory
+     */
+    protected function deleteDirectory(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        $files = array_diff(scandir($dir), ['.', '..']);
+        foreach ($files as $file) {
+            $path = $dir . DIRECTORY_SEPARATOR . $file;
+            is_dir($path) ? $this->deleteDirectory($path) : unlink($path);
+        }
+        rmdir($dir);
+    }
+}

--- a/packages/media/src/MediaHandler/ChunkedMediaHandler.php
+++ b/packages/media/src/MediaHandler/ChunkedMediaHandler.php
@@ -1,0 +1,311 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravolt\Media\MediaHandler;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
+use Laravolt\Platform\Models\Guest;
+use Pion\Laravel\ChunkUpload\Exceptions\UploadFailedException;
+use Pion\Laravel\ChunkUpload\Exceptions\UploadMissingFileException;
+use Pion\Laravel\ChunkUpload\Handler\HandlerFactory;
+use Pion\Laravel\ChunkUpload\Receiver\FileReceiver;
+use Spatie\MediaLibrary\MediaCollections\Exceptions\FileCannotBeAdded;
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
+
+class ChunkedMediaHandler
+{
+    protected Request $request;
+
+    public function __construct(Request $request = null)
+    {
+        $this->request = $request ?? request();
+    }
+
+    public function __invoke()
+    {
+        $action = $this->request->input('_action', 'upload');
+
+        return $this->{$action}();
+    }
+
+    /**
+     * Handle chunk upload
+     */
+    protected function upload(): JsonResponse
+    {
+        try {
+            // Validate file if provided
+            if ($this->request->hasFile('file')) {
+                $this->validateFile($this->request->file('file'));
+            }
+
+            // Create file receiver
+            $receiver = new FileReceiver($this->request->file('file'), $this->request, HandlerFactory::classFromRequest($this->request));
+
+            // Check if upload is finished
+            if ($receiver->isFinished()) {
+                return $this->saveFile($receiver->receive());
+            }
+
+            // Handle chunk
+            $handler = $receiver->handler();
+            $content = $handler->getChunkContent();
+
+            if ($content === false) {
+                return response()->json([
+                    'success' => false,
+                    'message' => 'Failed to process chunk',
+                ], 400);
+            }
+
+            // Save chunk
+            $chunk = $handler->getChunkFile();
+            $chunk->storeAs('chunks', $handler->getChunkFileName(), 'local');
+
+            return response()->json([
+                'success' => true,
+                'done' => $handler->getPercentageDone(),
+                'chunk' => $handler->getChunkIndex(),
+                'total_chunks' => $handler->getTotalChunks(),
+            ]);
+
+        } catch (UploadFailedException $e) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Upload failed: ' . $e->getMessage(),
+            ], 400);
+        } catch (UploadMissingFileException $e) {
+            return response()->json([
+                'success' => false,
+                'message' => 'No file uploaded',
+            ], 400);
+        } catch (\Exception $e) {
+            report($e);
+            
+            return response()->json([
+                'success' => false,
+                'message' => 'An error occurred during upload',
+            ], 500);
+        }
+    }
+
+    /**
+     * Complete upload and save to media library
+     */
+    protected function complete(): JsonResponse
+    {
+        try {
+            $fileId = $this->request->input('file_id');
+            $fileName = $this->request->input('file_name');
+            
+            if (!$fileId || !$fileName) {
+                return response()->json([
+                    'success' => false,
+                    'message' => 'Missing file_id or file_name',
+                ], 400);
+            }
+
+            // Get the completed file
+            $filePath = storage_path("app/chunks/{$fileId}/{$fileName}");
+            
+            if (!file_exists($filePath)) {
+                return response()->json([
+                    'success' => false,
+                    'message' => 'File not found',
+                ], 404);
+            }
+
+            // Get user (authenticated or guest)
+            /** @var \Spatie\MediaLibrary\InteractsWithMedia $user */
+            $user = auth()->user() ?? Guest::first();
+
+            // Add to media library
+            $media = $user->addMedia($filePath)->toMediaCollection();
+
+            // Clean up chunks
+            $this->cleanupChunks($fileId);
+
+            return response()->json([
+                'success' => true,
+                'files' => [
+                    [
+                        'file' => $media->getUrl(),
+                        'name' => $media->file_name,
+                        'size' => $media->size,
+                        'type' => $media->mime_type,
+                        'data' => [
+                            'id' => $media->getKey(),
+                            'url' => $media->getUrl(),
+                            'thumbnail' => $media->getUrl(),
+                        ],
+                    ],
+                ],
+            ]);
+
+        } catch (FileCannotBeAdded $e) {
+            return response()->json([
+                'success' => false,
+                'message' => $e->getMessage(),
+            ], 400);
+        } catch (\Exception $e) {
+            report($e);
+            
+            return response()->json([
+                'success' => false,
+                'message' => 'An error occurred while saving file',
+            ], 500);
+        }
+    }
+
+    /**
+     * Delete media
+     */
+    protected function delete(): JsonResponse
+    {
+        try {
+            /** @var Model */
+            $model = config('media-library.media_model');
+            /** @var Media */
+            $media = $model::query()->findOrFail($this->request->input('id'));
+            $media->delete();
+
+            return response()->json(['success' => true]);
+        } catch (\Exception $e) {
+            report($e);
+            
+            return response()->json([
+                'success' => false,
+                'message' => 'Failed to delete media',
+            ], 500);
+        }
+    }
+
+    /**
+     * Save completed file
+     */
+    protected function saveFile($file)
+    {
+        try {
+            // Get user (authenticated or guest)
+            /** @var \Spatie\MediaLibrary\InteractsWithMedia $user */
+            $user = auth()->user() ?? Guest::first();
+
+            // Add to media library
+            $media = $user->addMedia($file->getPathname())->toMediaCollection();
+
+            // Clean up temporary file
+            unlink($file->getPathname());
+
+            return response()->json([
+                'success' => true,
+                'files' => [
+                    [
+                        'file' => $media->getUrl(),
+                        'name' => $media->file_name,
+                        'size' => $media->size,
+                        'type' => $media->mime_type,
+                        'data' => [
+                            'id' => $media->getKey(),
+                            'url' => $media->getUrl(),
+                            'thumbnail' => $media->getUrl(),
+                        ],
+                    ],
+                ],
+            ]);
+
+        } catch (FileCannotBeAdded $e) {
+            return response()->json([
+                'success' => false,
+                'message' => $e->getMessage(),
+            ], 400);
+        } catch (\Exception $e) {
+            report($e);
+            
+            return response()->json([
+                'success' => false,
+                'message' => 'An error occurred while saving file',
+            ], 500);
+        }
+    }
+
+    /**
+     * Clean up chunk files
+     */
+    protected function cleanupChunks(string $fileId): void
+    {
+        try {
+            $chunkPath = storage_path("app/chunks/{$fileId}");
+            if (is_dir($chunkPath)) {
+                $this->deleteDirectory($chunkPath);
+            }
+        } catch (\Exception $e) {
+            // Log error but don't fail the request
+            report($e);
+        }
+    }
+
+    /**
+     * Recursively delete directory
+     */
+    protected function deleteDirectory(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        $files = array_diff(scandir($dir), ['.', '..']);
+        foreach ($files as $file) {
+            $path = $dir . DIRECTORY_SEPARATOR . $file;
+            is_dir($path) ? $this->deleteDirectory($path) : unlink($path);
+        }
+        rmdir($dir);
+    }
+
+    /**
+     * Validate uploaded file
+     */
+    protected function validateFile($file): void
+    {
+        // Check if validation is enabled
+        if (!config('chunked-upload.security.validate_file_type', true) && 
+            !config('chunked-upload.security.validate_file_size', true)) {
+            return;
+        }
+
+        // Validate file size
+        if (config('chunked-upload.security.validate_file_size', true)) {
+            $maxSize = config('chunked-upload.max_file_size', 100 * 1024 * 1024);
+            if ($file->getSize() > $maxSize) {
+                throw new \Exception("File size exceeds maximum allowed size of " . $this->formatBytes($maxSize));
+            }
+        }
+
+        // Validate file type
+        if (config('chunked-upload.security.validate_file_type', true)) {
+            $allowedTypes = config('chunked-upload.allowed_types', []);
+            if (!empty($allowedTypes) && !in_array($file->getMimeType(), $allowedTypes)) {
+                throw new \Exception("File type '{$file->getMimeType()}' is not allowed");
+            }
+        }
+    }
+
+    /**
+     * Format bytes to human readable format
+     */
+    protected function formatBytes(int $bytes): string
+    {
+        if ($bytes === 0) {
+            return '0 Bytes';
+        }
+        
+        $k = 1024;
+        $sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB'];
+        $i = floor(log($bytes) / log($k));
+        
+        return round($bytes / pow($k, $i), 2) . ' ' . $sizes[$i];
+    }
+}

--- a/packages/media/src/ServiceProvider.php
+++ b/packages/media/src/ServiceProvider.php
@@ -15,7 +15,7 @@ class ServiceProvider extends BaseServiceProvider
 {
     public function boot()
     {
-        $this->bootRoutes()->bootMacro();
+        $this->bootRoutes()->bootMacro()->bootConfig();
     }
 
     protected function bootRoutes()
@@ -30,6 +30,15 @@ class ServiceProvider extends BaseServiceProvider
         Request::macro('media', function ($key) {
             return new MediaInputBag($key);
         });
+
+        return $this;
+    }
+
+    protected function bootConfig()
+    {
+        $this->publishes([
+            __DIR__.'/../config/chunked-upload.php' => config_path('chunked-upload.php'),
+        ], 'chunked-upload-config');
 
         return $this;
     }

--- a/packages/media/tests/ChunkedMediaHandlerTest.php
+++ b/packages/media/tests/ChunkedMediaHandlerTest.php
@@ -1,0 +1,282 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravolt\Media\Tests;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Laravolt\Media\MediaHandler\ChunkedMediaHandler;
+use Laravolt\Platform\Models\Guest;
+use Laravolt\Platform\Models\User;
+use Tests\TestCase;
+
+class ChunkedMediaHandlerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Storage::fake('local');
+    }
+
+    /** @test */
+    public function it_can_handle_chunk_upload()
+    {
+        // Create a test user
+        $user = User::factory()->create();
+
+        // Create a test file
+        $file = UploadedFile::fake()->create('test-file.txt', 1024);
+
+        // Mock the request with chunk data
+        $request = request();
+        $request->merge([
+            'handler' => 'chunked',
+            '_action' => 'upload',
+        ]);
+        $request->files->set('file', $file);
+
+        // Create handler instance
+        $handler = new ChunkedMediaHandler($request);
+
+        // Execute the handler
+        $response = $handler();
+
+        // Assert response
+        $this->assertEquals(200, $response->getStatusCode());
+        $responseData = json_decode($response->getContent(), true);
+        $this->assertTrue($responseData['success']);
+    }
+
+    /** @test */
+    public function it_can_handle_guest_upload()
+    {
+        // Create a guest user
+        $guest = Guest::first();
+
+        // Create a test file
+        $file = UploadedFile::fake()->create('guest-file.txt', 1024);
+
+        // Mock the request
+        $request = request();
+        $request->merge([
+            'handler' => 'chunked',
+            '_action' => 'upload',
+        ]);
+        $request->files->set('file', $file);
+
+        // Create handler instance
+        $handler = new ChunkedMediaHandler($request);
+
+        // Execute the handler
+        $response = $handler();
+
+        // Assert response
+        $this->assertEquals(200, $response->getStatusCode());
+        $responseData = json_decode($response->getContent(), true);
+        $this->assertTrue($responseData['success']);
+    }
+
+    /** @test */
+    public function it_can_handle_complete_upload()
+    {
+        // Create a test user
+        $user = User::factory()->create();
+
+        // Create a temporary file
+        $tempFile = tempnam(sys_get_temp_dir(), 'test');
+        file_put_contents($tempFile, 'test content');
+
+        // Mock the request for complete action
+        $request = request();
+        $request->merge([
+            'handler' => 'chunked',
+            '_action' => 'complete',
+            'file_id' => 'test-file-id',
+            'file_name' => 'test-file.txt',
+        ]);
+
+        // Mock file existence
+        $chunkPath = storage_path('app/chunks/test-file-id/test-file.txt');
+        $chunkDir = dirname($chunkPath);
+        if (!is_dir($chunkDir)) {
+            mkdir($chunkDir, 0755, true);
+        }
+        copy($tempFile, $chunkPath);
+
+        // Create handler instance
+        $handler = new ChunkedMediaHandler($request);
+
+        // Execute the handler
+        $response = $handler();
+
+        // Assert response
+        $this->assertEquals(200, $response->getStatusCode());
+        $responseData = json_decode($response->getContent(), true);
+        $this->assertTrue($responseData['success']);
+        $this->assertArrayHasKey('files', $responseData);
+        $this->assertCount(1, $responseData['files']);
+
+        // Clean up
+        unlink($tempFile);
+        if (file_exists($chunkPath)) {
+            unlink($chunkPath);
+            rmdir($chunkDir);
+        }
+    }
+
+    /** @test */
+    public function it_can_handle_delete_media()
+    {
+        // Create a test user
+        $user = User::factory()->create();
+
+        // Create a media item
+        $media = $user->addMedia(UploadedFile::fake()->create('test-file.txt', 1024))
+            ->toMediaCollection();
+
+        // Mock the request for delete action
+        $request = request();
+        $request->merge([
+            'handler' => 'chunked',
+            '_action' => 'delete',
+            'id' => $media->id,
+        ]);
+
+        // Create handler instance
+        $handler = new ChunkedMediaHandler($request);
+
+        // Execute the handler
+        $response = $handler();
+
+        // Assert response
+        $this->assertEquals(200, $response->getStatusCode());
+        $responseData = json_decode($response->getContent(), true);
+        $this->assertTrue($responseData['success']);
+
+        // Assert media is deleted
+        $this->assertDatabaseMissing('media', ['id' => $media->id]);
+    }
+
+    /** @test */
+    public function it_handles_upload_errors_gracefully()
+    {
+        // Mock the request without file
+        $request = request();
+        $request->merge([
+            'handler' => 'chunked',
+            '_action' => 'upload',
+        ]);
+
+        // Create handler instance
+        $handler = new ChunkedMediaHandler($request);
+
+        // Execute the handler
+        $response = $handler();
+
+        // Assert error response
+        $this->assertEquals(400, $response->getStatusCode());
+        $responseData = json_decode($response->getContent(), true);
+        $this->assertFalse($responseData['success']);
+        $this->assertArrayHasKey('message', $responseData);
+    }
+
+    /** @test */
+    public function it_handles_complete_upload_without_file()
+    {
+        // Mock the request for complete action without file
+        $request = request();
+        $request->merge([
+            'handler' => 'chunked',
+            '_action' => 'complete',
+        ]);
+
+        // Create handler instance
+        $handler = new ChunkedMediaHandler($request);
+
+        // Execute the handler
+        $response = $handler();
+
+        // Assert error response
+        $this->assertEquals(400, $response->getStatusCode());
+        $responseData = json_decode($response->getContent(), true);
+        $this->assertFalse($responseData['success']);
+        $this->assertStringContains('Missing file_id or file_name', $responseData['message']);
+    }
+
+    /** @test */
+    public function it_handles_complete_upload_with_nonexistent_file()
+    {
+        // Mock the request for complete action with nonexistent file
+        $request = request();
+        $request->merge([
+            'handler' => 'chunked',
+            '_action' => 'complete',
+            'file_id' => 'nonexistent-file-id',
+            'file_name' => 'nonexistent-file.txt',
+        ]);
+
+        // Create handler instance
+        $handler = new ChunkedMediaHandler($request);
+
+        // Execute the handler
+        $response = $handler();
+
+        // Assert error response
+        $this->assertEquals(404, $response->getStatusCode());
+        $responseData = json_decode($response->getContent(), true);
+        $this->assertFalse($responseData['success']);
+        $this->assertStringContains('File not found', $responseData['message']);
+    }
+
+    /** @test */
+    public function it_returns_consistent_response_format()
+    {
+        // Create a test user
+        $user = User::factory()->create();
+
+        // Create a test file
+        $file = UploadedFile::fake()->create('test-file.txt', 1024);
+
+        // Mock the request
+        $request = request();
+        $request->merge([
+            'handler' => 'chunked',
+            '_action' => 'upload',
+        ]);
+        $request->files->set('file', $file);
+
+        // Create handler instance
+        $handler = new ChunkedMediaHandler($request);
+
+        // Execute the handler
+        $response = $handler();
+
+        // Assert response format
+        $responseData = json_decode($response->getContent(), true);
+        $this->assertArrayHasKey('success', $responseData);
+        
+        if ($responseData['success']) {
+            $this->assertArrayHasKey('files', $responseData);
+            $this->assertIsArray($responseData['files']);
+            
+            if (!empty($responseData['files'])) {
+                $fileData = $responseData['files'][0];
+                $this->assertArrayHasKey('file', $fileData);
+                $this->assertArrayHasKey('name', $fileData);
+                $this->assertArrayHasKey('size', $fileData);
+                $this->assertArrayHasKey('type', $fileData);
+                $this->assertArrayHasKey('data', $fileData);
+                
+                $this->assertArrayHasKey('id', $fileData['data']);
+                $this->assertArrayHasKey('url', $fileData['data']);
+                $this->assertArrayHasKey('thumbnail', $fileData['data']);
+            }
+        } else {
+            $this->assertArrayHasKey('message', $responseData);
+        }
+    }
+}


### PR DESCRIPTION
Add chunked upload support to handle large files and prevent 413 "Payload Too Large" errors without server configuration changes.

Existing media handlers send entire files, leading to 413 errors for large uploads in environments like Laravel Cloud. This PR implements client-side chunking and server-side reassembly using `pion/laravel-chunk-upload`, aligning with Laravolt's architecture and Spatie Media Library, ensuring compatibility and scalability.

---
<a href="https://cursor.com/background-agent?bcId=bc-36dfd5c4-1597-4db3-99d8-3c0ecc14f9ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-36dfd5c4-1597-4db3-99d8-3c0ecc14f9ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

