### PR TITLE
feat(preline-form): add showIf/hideIf for conditional field visibility

### DIFF
--- a/packages/preline-form/src/Elements/Element.php
+++ b/packages/preline-form/src/Elements/Element.php
@@ -20,6 +20,12 @@ abstract class Element
 
     protected $hint = [];
 
+    /** @var string|null Alpine.js x-show expression */
+    protected $showIfExpression = null;
+
+    /** @var string|null Alpine.js x-data init expression (for binding) */
+    protected $alpineData = null;
+
     public function __toString()
     {
         try {
@@ -30,6 +36,29 @@ abstract class Element
     }
 
     abstract public function render();
+
+    /**
+     * Show this field only when the given Alpine.js expression is truthy.
+     * Example: ->showIf('type === "company"')
+     */
+    public function showIf(string $expression): static
+    {
+        $this->showIfExpression = $expression;
+
+        return $this;
+    }
+
+    /**
+     * Hide this field when the given Alpine.js expression is truthy.
+     * Equivalent to showIf with a negated expression.
+     * Example: ->hideIf('type === "individual"')
+     */
+    public function hideIf(string $expression): static
+    {
+        $this->showIfExpression = "!({$expression})";
+
+        return $this;
+    }
 
     public function hasAttribute($attribute)
     {
@@ -283,9 +312,10 @@ abstract class Element
         $error = $this->renderError();
         $hint = $this->renderHint();
         $stateField = $this->renderFieldState();
+        $showIfAttr = $this->renderShowIfAttribute();
 
         return <<<HTML
-          <div>
+          <div{$showIfAttr}>
             $label
 
             <div class="relative">
@@ -394,5 +424,18 @@ abstract class Element
             </svg>
           </div>
         HTML;
+    }
+
+    /**
+     * Render x-show attribute if showIf/hideIf was called.
+     * The wrapping field div will carry the Alpine.js directive.
+     */
+    protected function renderShowIfAttribute(): string
+    {
+        if ($this->showIfExpression === null) {
+            return '';
+        }
+
+        return sprintf(' x-show="%s"', htmlspecialchars($this->showIfExpression, ENT_QUOTES));
     }
 }


### PR DESCRIPTION
## Summary

Closes #32

Adds `.showIf()` and `.hideIf()` methods to all preline-form elements, enabling Alpine.js-powered conditional field rendering without writing any JavaScript.

## How it works

The `x-show` directive is rendered on the wrapping `<div>` of the field, so the entire field — label, input, error message, and hint — is toggled together.

Requires Alpine.js to be loaded in the layout (already a dependency of Preline UI).

## Usage

```blade
{{-- Show a field only when a condition is met --}}
{!! Form::text('company_name')
    ->label('Company Name')
    ->showIf('type === "company"') !!}

{{-- Hide a field when a condition is met --}}
{!! Form::text('full_name')
    ->label('Full Name')
    ->hideIf('type === "company"') !!}
```

The `x-data` Alpine state should be defined on the parent form or a wrapper element:

```blade
<div x-data="{ type: 'individual' }">
    {!! Form::select('type', ['individual' => 'Individual', 'company' => 'Company'])
        ->label('Type')
        ->attribute('x-model', 'type') !!}

    {!! Form::text('full_name')->label('Full Name')->hideIf('type === "company"') !!}
    {!! Form::text('company_name')->label('Company Name')->showIf('type === "company"') !!}
</div>
```

## Changes

- `Element.php`: Added `$showIfExpression` property, `showIf()`, `hideIf()`, and `renderShowIfAttribute()` methods. The `renderField()` method now applies `x-show` on the outer wrapper div.