### PR TITLE
⚡ Bolt: Replace collection overhead with native array lookup in AutoFilter

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-14 - Collection overhead in query builder traits
+**Learning:** Found an anti-pattern in `packages/suitable/src/AutoFilter.php` where `collect($castField)->filter(...)` was used simply to check if an array key exists and matches a value, which gets executed in a loop for every query filter. This introduces severe object allocation and closure execution overhead in what should be a fast query building path.
+**Action:** Always prefer native array functions or direct hash map lookups (`isset($array[$key]) && $array[$key] === $value`) over Collection instances for simple array checks, especially inside loops or hot paths like Query Builder macros and traits.

--- a/packages/suitable/src/AutoFilter.php
+++ b/packages/suitable/src/AutoFilter.php
@@ -57,11 +57,6 @@ trait AutoFilter
             $jsonFieldName = Str::beforeLast($column, '.');
         }
 
-        // Filter item, with key == column  and value is array
-        $found = collect($castField)->filter(function ($value, $key) use ($jsonFieldName) {
-            return $key === $jsonFieldName && $value === 'array';
-        });
-
-        return count($found) > 0;
+        return isset($castField[$jsonFieldName]) && $castField[$jsonFieldName] === 'array';
     }
 }


### PR DESCRIPTION
💡 **What**: Replaced a costly `collect()->filter()` operation inside the `isJsonColumn` loop of `packages/suitable/src/AutoFilter.php` with an O(1) native hash map lookup (`isset()`).
🎯 **Why**: Using Collections for simple array checks inside a loop adds severe overhead through unnecessary object allocations, function calls, and closure executions.
📊 **Impact**: Reduces object allocation overhead and execution time in the AutoFilter query-building hot path, particularly when multiple filters are applied.
🔬 **Measurement**: Inspect the time taken and memory allocated during complex filter building using `AutoFilter`, or run generic Laravel benchmarks over the `AutoFilter` trait.

---
*PR created automatically by Jules for task [16387187303184109514](https://jules.google.com/task/16387187303184109514) started by @qisthidev*