### PR TITLE
🔒 Fix SQL Injection in QueryBuilderMixin via unescaped column name

### DIFF
--- a/packages/support/src/Mixin/QueryBuilderMixin.php
+++ b/packages/support/src/Mixin/QueryBuilderMixin.php
@@ -25,11 +25,14 @@ class QueryBuilderMixin
     public function whereLike()
     {
         return function ($attributes, ?string $searchTerm) {
-            if ($searchTerm) {
-                $searchTerm = mb_trim(DB::getPdo()->quote((mb_strtolower($searchTerm))), "'");
+            if ($searchTerm !== null && mb_trim($searchTerm) !== '') {
+                $searchTerm = mb_strtolower(mb_trim($searchTerm));
                 $this->where(function (Builder $query) use ($attributes, $searchTerm) {
                     foreach (Arr::wrap($attributes) as $column) {
-                        $query->orWhereRaw(sprintf("LOWER(%s) LIKE '%%%s%%'", $column, $searchTerm));
+                        $query->orWhereRaw(
+                            sprintf('LOWER(%s) LIKE ?', $query->getGrammar()->wrap($column)),
+                            ["%$searchTerm%"]
+                        );
                     }
                 });
             }

--- a/packages/support/src/Mixin/QueryBuilderMixin.php
+++ b/packages/support/src/Mixin/QueryBuilderMixin.php
@@ -6,7 +6,6 @@ namespace Laravolt\Support\Mixin;
 
 use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Facades\DB;
 
 class QueryBuilderMixin
 {

--- a/packages/support/src/SupportServiceProvider.php
+++ b/packages/support/src/SupportServiceProvider.php
@@ -32,7 +32,7 @@ class SupportServiceProvider extends ServiceProvider
                 return $this;
             }
 
-            $searchTerm = mb_trim(DB::getPdo()->quote((mb_strtolower($searchTerm))), "'");
+            $searchTerm = mb_strtolower(mb_trim($searchTerm));
             $this->where(function (EloquentBuilder $query) use ($attributes, $searchTerm) {
                 foreach (Arr::wrap($attributes) as $attribute) {
                     $query->when(
@@ -43,11 +43,10 @@ class SupportServiceProvider extends ServiceProvider
                             $query->orWhereHas(
                                 $relationName,
                                 function (EloquentBuilder $query) use ($relationAttribute, $searchTerm) {
-                                    $query->whereRaw(sprintf(
-                                        "LOWER(%s) LIKE '%%%s%%'",
-                                        $relationAttribute,
-                                        $searchTerm
-                                    ));
+                                    $query->whereRaw(
+                                        sprintf('LOWER(%s) LIKE ?', $query->getQuery()->getGrammar()->wrap($relationAttribute)),
+                                        ["%$searchTerm%"]
+                                    );
                                 }
                             );
                         },
@@ -56,12 +55,10 @@ class SupportServiceProvider extends ServiceProvider
                             if (Str::contains($attribute, '->')) {
                                 $query->orWhere($attribute, 'ilike', "%$searchTerm%");
                             } else {
-                                $query->orWhereRaw(sprintf(
-                                    "LOWER(%s.%s) LIKE '%%%s%%'",
-                                    $table,
-                                    $attribute,
-                                    $searchTerm
-                                ));
+                                $query->orWhereRaw(
+                                    sprintf('LOWER(%s.%s) LIKE ?', $query->getQuery()->getGrammar()->wrap($table), $query->getQuery()->getGrammar()->wrap($attribute)),
+                                    ["%$searchTerm%"]
+                                );
                             }
                         }
                     );

--- a/packages/support/src/SupportServiceProvider.php
+++ b/packages/support/src/SupportServiceProvider.php
@@ -7,7 +7,6 @@ namespace Laravolt\Support;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;
 use Laravolt\Support\Mixin\QueryBuilderMixin;

--- a/tests/Unit/Support/WhereLikeSecurityRegressionTest.php
+++ b/tests/Unit/Support/WhereLikeSecurityRegressionTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravolt\Tests\Unit\Support;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\DB;
+use Laravolt\Support\SupportServiceProvider;
+use Laravolt\Tests\UnitTest;
+
+class WhereLikeSecurityRegressionTest extends UnitTest
+{
+    protected function getEnvironmentSetUp($app): void
+    {
+        $app['config']->set('database.default', 'sqlite');
+        $app['config']->set('database.connections.sqlite.database', ':memory:');
+    }
+
+    protected function getPackageProviders($app): array
+    {
+        return [
+            SupportServiceProvider::class,
+        ];
+    }
+
+    public function test_query_builder_where_like_uses_wrapped_identifier_and_binding(): void
+    {
+        $query = DB::table('users')->whereLike('name', 'John Doe');
+        $expectedFragment = sprintf('LOWER(%s) LIKE ?', $query->getGrammar()->wrap('name'));
+
+        $this->assertStringContainsString($expectedFragment, $query->toSql());
+        $this->assertContains('%john doe%', $query->getBindings());
+        $this->assertStringNotContainsString('%john doe%', $query->toSql());
+    }
+
+    public function test_eloquent_where_like_direct_column_uses_wrapped_identifier_and_binding(): void
+    {
+        $query = WhereLikeSecurityUser::query()->whereLike('name', 'John Doe');
+        $grammar = $query->getQuery()->getGrammar();
+        $expectedFragment = sprintf(
+            'LOWER(%s.%s) LIKE ?',
+            $grammar->wrap($query->getModel()->getTable()),
+            $grammar->wrap('name')
+        );
+
+        $this->assertStringContainsString($expectedFragment, $query->toSql());
+        $this->assertContains('%john doe%', $query->getBindings());
+        $this->assertStringNotContainsString('%john doe%', $query->toSql());
+    }
+
+    public function test_eloquent_where_like_relation_column_uses_wrapped_identifier_and_binding(): void
+    {
+        $query = WhereLikeSecurityUser::query()->whereLike('profile.bio', 'John Doe');
+        $expectedFragment = sprintf('LOWER(%s) LIKE ?', $query->getQuery()->getGrammar()->wrap('bio'));
+
+        $this->assertStringContainsString($expectedFragment, $query->toSql());
+        $this->assertContains('%john doe%', $query->getBindings());
+        $this->assertStringNotContainsString('%john doe%', $query->toSql());
+    }
+}
+
+class WhereLikeSecurityUser extends Model
+{
+    protected $table = 'users';
+    public $timestamps = false;
+
+    public function profile()
+    {
+        return $this->hasOne(WhereLikeSecurityProfile::class, 'user_id');
+    }
+}
+
+class WhereLikeSecurityProfile extends Model
+{
+    protected $table = 'profiles';
+    public $timestamps = false;
+}

--- a/tests/Unit/Support/WhereLikeSecurityRegressionTest.php
+++ b/tests/Unit/Support/WhereLikeSecurityRegressionTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Laravolt\Tests\Unit\Support;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Support\Facades\DB;
 use Laravolt\Support\SupportServiceProvider;
 use Laravolt\Tests\UnitTest;
@@ -65,7 +66,7 @@ class WhereLikeSecurityUser extends Model
     protected $table = 'users';
     public $timestamps = false;
 
-    public function profile()
+    public function profile(): HasOne
     {
         return $this->hasOne(WhereLikeSecurityProfile::class, 'user_id');
     }


### PR DESCRIPTION
🎯 **What:** Fixed a critical SQL Injection vulnerability in the `whereLike` method/macro.
⚠️ **Risk:** Attackers could inject malicious SQL through filter keys or unescaped search terms, potentially leading to unauthorized data access or database manipulation.
🛡️ **Solution:** Implemented proper identifier escaping using Laravel's Query Grammar and switched to parameter bindings for values, ensuring all user-controlled input is safely handled in raw SQL blocks.

---
*PR created automatically by Jules for task [300597913259556555](https://jules.google.com/task/300597913259556555) started by @qisthidev*