### PR TITLE
⚡ Bolt: Optimize cached permissions Collection memory allocations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,4 @@
+
+## 2024-05-25 - Use Collections `contains` instead of `where()->first()` for caching checks
+**Learning:** When using cached Eloquent Collections (such as returning all permissions for a user via `Cache::remember`), using `$collection->where('key', $value)->first()` creates a brand new Collection instance by filtering the array, and then returns the first element. This causes unnecessary memory allocations and iterations over the full collection. Using `$collection->contains('key', $value)` natively short-circuits the iteration as soon as a match is found and avoids instantiating new collections, providing an O(1) space and O(N) worst-case (but average better-case) time complexity.
+**Action:** Always prefer `$collection->contains()` over `firstWhere()` or `where()->first()` when doing simple existence checks on Collections to avoid memory bloat.

--- a/src/Platform/Concerns/HasRoleAndPermission.php
+++ b/src/Platform/Concerns/HasRoleAndPermission.php
@@ -94,25 +94,19 @@ trait HasRoleAndPermission
         }
 
         if (Str::isUuid($role)) {
-            $role = $this->roles->firstWhere('id', $role);
+            return $this->roles->contains('id', $role);
         }
 
         if (is_string($role)) {
-            $role = $this->roles->firstWhere('name', $role);
+            return $this->roles->contains('name', $role);
         }
 
         if (is_int($role)) {
-            $role = $this->roles->firstWhere('id', $role);
+            return $this->roles->contains('id', $role);
         }
 
-        if (! $role instanceof Model) {
-            return false;
-        }
-
-        foreach ($this->roles as $assignedRole) {
-            if ($role->is($assignedRole)) {
-                return true;
-            }
+        if ($role instanceof Model) {
+            return $this->roles->contains($role);
         }
 
         return false;
@@ -174,19 +168,19 @@ trait HasRoleAndPermission
         }
 
         if (Str::isUuid($permission)) {
-            return (bool) $this->permissions()->where('id', $permission)->first();
+            return $this->permissions()->contains('id', $permission);
         }
 
         if (is_string($permission)) {
-            return (bool) $this->permissions()->where('name', $permission)->first();
+            return $this->permissions()->contains('name', $permission);
         }
 
         if (is_int($permission)) {
-            return (bool) $this->permissions()->where('id', $permission)->first();
+            return $this->permissions()->contains('id', $permission);
         }
 
         if ($permission instanceof Model) {
-            return (bool) $this->permissions()->where('id', $permission->id)->first()?->getKey();
+            return $this->permissions()->contains('id', $permission->getKey());
         }
 
         return false;


### PR DESCRIPTION
💡 What: Replaced `where()->first()` and `firstWhere()` inside `hasRole` and `hasPermission` with `contains()`.
🎯 Why: Using `$collection->where('key', 'value')->first()` on a cached Collection filters the entire array to build a new Collection before retrieving the first item. Using `contains()` natively short-circuits the iteration as soon as a match is found and completely removes the object allocation overhead (O(N) space reduced to O(1) space).
📊 Impact: Reduces memory overhead for application permission verification logic and removes O(N) array duplication during cache hits.
🔬 Measurement: Verify tests run completely, or manually inspect cache behavior using a trace profiler to see object creation count drop.

---
*PR created automatically by Jules for task [7710367030074975453](https://jules.google.com/task/7710367030074975453) started by @qisthidev*