### PR TITLE
⚡ Bolt: Optimize Role::hasPermission to avoid N+1 queries

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2024-05-15 - Array check performance issue in ACL
 **Learning:** Checking roles and permissions array sequentially via full evaluation, without exiting early, causes a noticeable O(n^2) scaling when checking lots of items.
 **Action:** Always short circuit and return early in arrays evaluations and replace sequential array scans on collections with `.contains('key', 'val')` lookups.
+
+## 2024-05-24 - Avoid N+1 in Role::hasPermission
+**Learning:** Checking permissions on `Role` using `hasPermission()` was previously doing an unnecessary database query (`first()`) for every check instead of using the already loaded `permissions` relationship. This resulted in an N+1 queries issue, significantly impacting performance when dealing with many permissions checks.
+**Action:** For simple existence checks within an Eloquent model, use the Eloquent Collection's `contains` method on the loaded relationship instead of querying the database directly. This leverages the in-memory array representation which is substantially faster.

--- a/src/Platform/Models/Role.php
+++ b/src/Platform/Models/Role.php
@@ -82,28 +82,19 @@ class Role extends Model
 
     protected function _hasPermission($permission)
     {
-        $model = $permission;
         $permissionModel = app(config('laravolt.epicentrum.models.permission'));
+        $keyName = $permissionModel->getKeyName();
 
-        if (! $model instanceof Model) {
-            if (is_int($permission)) {
-                $model = $permissionModel->find($permission);
-            } elseif (is_string($permission)) {
-                $model = match ($permissionModel->getKeyType()) {
-                    'int' => $permissionModel->where('name', $permission)->first(),
-                    'string' => $permissionModel->whereKey($permission)->orWhere('name', $permission)->first(),
-                };
-            }
+        if (is_int($permission)) {
+            return $this->permissions->contains($keyName, $permission);
         }
 
-        if (! $model instanceof Model) {
-            return false;
+        if (is_string($permission)) {
+            return $this->permissions->contains($keyName, $permission) || $this->permissions->contains('name', $permission);
         }
 
-        foreach ($this->permissions as $assignedPermission) {
-            if ($model->is($assignedPermission)) {
-                return true;
-            }
+        if ($permission instanceof Model) {
+            return $this->permissions->contains($permission->getKeyName(), $permission->getKey());
         }
 
         return false;


### PR DESCRIPTION
💡 What: Changed `Laravolt\Platform\Models\Role::_hasPermission()` to use `$this->permissions->contains(...)` instead of making a direct `$permissionModel->where(...)` query.
🎯 Why: Calling `hasPermission` on a Role executed a database query every single time, leading to an N+1 problem, particularly severe in views or loops that check multiple permissions on an already loaded Role instance. 
📊 Impact: Reduces database queries for `Role::hasPermission()` checks from O(N) to O(1) by leveraging the model's in-memory Eloquent Collection. This significantly lowers execution time for permission checks.
🔬 Measurement: Verified using scratchpad scripts that query count drops from N to 0 when repeatedly checking permissions on a Role instance.

---
*PR created automatically by Jules for task [2036524429432676263](https://jules.google.com/task/2036524429432676263) started by @qisthidev*