### PR TITLE
⚡ Bolt: Optimize Role::_hasPermission to prevent N+1 queries

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2024-05-15 - Array check performance issue in ACL
 **Learning:** Checking roles and permissions array sequentially via full evaluation, without exiting early, causes a noticeable O(n^2) scaling when checking lots of items.
 **Action:** Always short circuit and return early in arrays evaluations and replace sequential array scans on collections with `.contains('key', 'val')` lookups.
+
+## 2024-05-16 - Collection N+1 Query Anti-Pattern in Roles
+**Learning:** Found a sneaky N+1 anti-pattern in `src/Platform/Models/Role.php` where checking permissions via string or ID executed database queries `first()` or `find()` instead of checking the eager-loaded `$this->permissions` collection.
+**Action:** Always verify if a relationship is eager-loaded before issuing database queries inside model methods. Use Eloquent Collection methods like `$collection->contains('name', $value)` to check existence in memory without database queries.

--- a/src/Platform/Models/Role.php
+++ b/src/Platform/Models/Role.php
@@ -51,59 +51,58 @@ class Role extends Model
 
     public function hasPermission($permission)
     {
-        return once(function () use ($permission) {
-            return $this->_hasPermission($permission);
-        });
+        return once(
+            function () use ($permission) {
+                return $this->_hasPermission($permission);
+            }
+        );
     }
 
     public function syncPermission(array $permissions)
     {
-        $ids = collect($permissions)->transform(function ($permission) {
-            if (str($permission)->isUlid()) {
-                return (string) $permission;
-            }
-            if (is_numeric($permission)) {
-                return (int) $permission;
-            }
-            if (is_string($permission)) {
-                $permissionObject = app(config('laravolt.epicentrum.models.permission'))->firstOrCreate(['name' => $permission]);
+        $ids = collect($permissions)->transform(
+            function ($permission) {
+                if (str($permission)->isUlid()) {
+                    return (string) $permission;
+                }
+                if (is_numeric($permission)) {
+                    return (int) $permission;
+                }
+                if (is_string($permission)) {
+                    $permissionObject = app(config('laravolt.epicentrum.models.permission'))->firstOrCreate(['name' => $permission]);
 
-                return $permissionObject->getKey();
+                    return $permissionObject->getKey();
+                }
+                if ($permission instanceof Model) {
+                    return $permission->getKey();
+                }
             }
-            if ($permission instanceof Model) {
-                return $permission->getKey();
+        )->filter(
+            function ($id) {
+                return $id > 0;
             }
-        })->filter(function ($id) {
-            return $id > 0;
-        });
+        );
 
         return $this->permissions()->sync($ids->toArray());
     }
 
     protected function _hasPermission($permission)
     {
-        $model = $permission;
-        $permissionModel = app(config('laravolt.epicentrum.models.permission'));
-
-        if (! $model instanceof Model) {
-            if (is_int($permission)) {
-                $model = $permissionModel->find($permission);
-            } elseif (is_string($permission)) {
-                $model = match ($permissionModel->getKeyType()) {
-                    'int' => $permissionModel->where('name', $permission)->first(),
-                    'string' => $permissionModel->whereKey($permission)->orWhere('name', $permission)->first(),
-                };
-            }
+        if ($permission instanceof Model) {
+            return $this->permissions->contains($permission);
         }
 
-        if (! $model instanceof Model) {
-            return false;
+        if (is_int($permission)) {
+            return $this->permissions->contains('id', $permission);
         }
 
-        foreach ($this->permissions as $assignedPermission) {
-            if ($model->is($assignedPermission)) {
-                return true;
-            }
+        if (is_string($permission)) {
+            $permissionModel = app(config('laravolt.epicentrum.models.permission'));
+
+            return match ($permissionModel->getKeyType()) {
+                'int' => $this->permissions->contains('name', $permission),
+                'string' => $this->permissions->contains('id', $permission) || $this->permissions->contains('name', $permission),
+            };
         }
 
         return false;


### PR DESCRIPTION
💡 **What**: The optimization changes `Role::_hasPermission` to check the eager-loaded `$this->permissions` collection for string or ID inputs instead of executing a new database query.
🎯 **Why**: When authorizing a role (checking if a role has a permission by string or ID), the existing code executed an unnecessary database query (`first()` or `find()`) before checking the collection, causing N+1 database queries on multiple authorization checks. 
📊 **Impact**: Reduces authorization database queries from O(N) to O(1) where N is the number of distinct checks during a request lifecycle, resulting in faster authorization responses.
🔬 **Measurement**: Run queries locally to verify `hasPermission` no longer hits the database for string inputs.

Fixes an anti-pattern in the ACL authorization logic.

---
*PR created automatically by Jules for task [2309271983125803200](https://jules.google.com/task/2309271983125803200) started by @qisthidev*