### PR TITLE
feat(preline-form): add declarative grid layout

### DIFF
--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: shivammathur/setup-php@v2
       with:
         php-version: '8.4'
-        extensions: bcmath, ctype, curl, dom, fileinfo, gd, mbstring, pdo_sqlite, sqlite3, tokenizer, xml, zip, xdebug
+        extensions: bcmath, ctype, curl, dom, exif, fileinfo, gd, mbstring, pdo_sqlite, sockets, sqlite3, tokenizer, xml, zip, xdebug
         coverage: xdebug
     - uses: actions/checkout@v4
     - name: Install Laravel

--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -33,8 +33,8 @@ jobs:
     - name: Install Dependencies
       run: |
         cd laravel
-        composer config repositories.laravolt path ./..
-        composer update -q --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist
+        composer config repositories.laravolt '{"type":"path","url":"./..","options":{"versions":{"laravolt/laravolt":"dev-master"}}}'
+        composer update --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist
         composer require brianium/paratest --dev --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist
     - name: Laravel Version
       run: php laravel/artisan --version

--- a/packages/preline-form/src/Elements/FieldLayout.php
+++ b/packages/preline-form/src/Elements/FieldLayout.php
@@ -1,0 +1,207 @@
+<?php
+
+namespace Laravolt\PrelineForm\Elements;
+
+use Laravolt\PrelineForm\FieldCollection;
+
+class FieldLayout extends Element
+{
+    protected FieldCollection $fields;
+
+    protected array $items;
+
+    protected string $type;
+
+    protected int $columns;
+
+    protected static array $columnClasses = [
+        1 => 'grid-cols-1',
+        2 => 'grid-cols-2',
+        3 => 'grid-cols-3',
+        4 => 'grid-cols-4',
+        5 => 'grid-cols-5',
+        6 => 'grid-cols-6',
+        7 => 'grid-cols-7',
+        8 => 'grid-cols-8',
+        9 => 'grid-cols-9',
+        10 => 'grid-cols-10',
+        11 => 'grid-cols-11',
+        12 => 'grid-cols-12',
+    ];
+
+    protected static array $spanClasses = [
+        1 => 'col-span-1',
+        2 => 'col-span-2',
+        3 => 'col-span-3',
+        4 => 'col-span-4',
+        5 => 'col-span-5',
+        6 => 'col-span-6',
+        7 => 'col-span-7',
+        8 => 'col-span-8',
+        9 => 'col-span-9',
+        10 => 'col-span-10',
+        11 => 'col-span-11',
+        12 => 'col-span-12',
+    ];
+
+    protected static array $gapClasses = [
+        0 => 'gap-0',
+        1 => 'gap-1',
+        2 => 'gap-2',
+        3 => 'gap-3',
+        4 => 'gap-4',
+        5 => 'gap-5',
+        6 => 'gap-6',
+        7 => 'gap-7',
+        8 => 'gap-8',
+        9 => 'gap-9',
+        10 => 'gap-10',
+        11 => 'gap-11',
+        12 => 'gap-12',
+    ];
+
+    protected static array $startClasses = [
+        1 => 'col-start-1',
+        2 => 'col-start-2',
+        3 => 'col-start-3',
+        4 => 'col-start-4',
+        5 => 'col-start-5',
+        6 => 'col-start-6',
+        7 => 'col-start-7',
+        8 => 'col-start-8',
+        9 => 'col-start-9',
+        10 => 'col-start-10',
+        11 => 'col-start-11',
+        12 => 'col-start-12',
+        13 => 'col-start-13',
+    ];
+
+    public function __construct(string $type, FieldCollection $fields, array $options = [])
+    {
+        $this->type = $type;
+        $this->fields = $fields;
+        $this->items = array_values($options['items'] ?? []);
+        $this->columns = $this->normalizeColumns($options['columns'] ?? $options['column'] ?? 1);
+
+        $this->attributes($options['attributes'] ?? []);
+        $this->addClass($this->containerClass($options));
+    }
+
+    public function render()
+    {
+        $output = sprintf('<div%s>', $this->renderAttributes());
+
+        foreach (array_values($this->fields->all()) as $index => $field) {
+            $output .= sprintf(
+                '<div class="%s">%s</div>',
+                form_escape($this->itemClass($this->items[$index] ?? [])),
+                $field
+            );
+        }
+
+        $output .= '</div>';
+
+        return $output;
+    }
+
+    public function bindValues(array $values)
+    {
+        $this->fields->bindValues($values);
+
+        return $this;
+    }
+
+    protected function containerClass(array $options): string
+    {
+        $classes = ['grid', static::$columnClasses[$this->columns], $this->gapClass($options['gap'] ?? 4)];
+
+        if (isset($options['classes'])) {
+            $classes[] = $options['classes'];
+        }
+
+        return trim(implode(' ', array_filter($classes)));
+    }
+
+    protected function itemClass($item): string
+    {
+        if (! is_array($item)) {
+            return 'col-span-1';
+        }
+
+        return trim(implode(' ', array_filter([
+            $this->spanClass($item['colSpan'] ?? $item['columnSpan'] ?? $item['width'] ?? null),
+            $this->startClass($item['colStart'] ?? $item['columnStart'] ?? $item['start'] ?? null),
+            $item['layoutClass'] ?? $item['wrapperClass'] ?? null,
+        ])));
+    }
+
+    protected function spanClass(mixed $span): string
+    {
+        if ($span === null) {
+            return 'col-span-1';
+        }
+
+        if ($span === 'full') {
+            return 'col-span-full';
+        }
+
+        if (is_string($span) && str_contains($span, '/')) {
+            return $this->fractionalSpanClass($span);
+        }
+
+        $span = (int) $span;
+        $span = max(1, min(12, $span));
+
+        return static::$spanClasses[$span];
+    }
+
+    protected function startClass(mixed $start): ?string
+    {
+        if ($start === null) {
+            return null;
+        }
+
+        $start = (int) $start;
+        $start = max(1, min(13, $start));
+
+        return static::$startClasses[$start];
+    }
+
+    protected function fractionalSpanClass(string $span): string
+    {
+        [$numerator, $denominator] = array_pad(explode('/', $span, 2), 2, 1);
+        $numerator = (int) $numerator;
+        $denominator = (int) $denominator;
+
+        if ($numerator <= 0 || $denominator <= 0) {
+            return 'col-span-1';
+        }
+
+        $columns = max(1, (int) round($this->columns * ($numerator / $denominator)));
+        $columns = min(12, $columns);
+
+        return static::$spanClasses[$columns];
+    }
+
+    protected function gapClass(int|string $gap): string
+    {
+        if (is_numeric($gap)) {
+            $gap = max(0, min(12, (int) $gap));
+
+            return static::$gapClasses[$gap];
+        }
+
+        if (in_array($gap, static::$gapClasses, true)) {
+            return $gap;
+        }
+
+        return static::$gapClasses[4];
+    }
+
+    protected function normalizeColumns(int|string $columns): int
+    {
+        $columns = (int) $columns;
+
+        return max(1, min(12, $columns));
+    }
+}

--- a/packages/preline-form/src/Elements/FieldLayout.php
+++ b/packages/preline-form/src/Elements/FieldLayout.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laravolt\PrelineForm\Elements;
 
 use Laravolt\PrelineForm\FieldCollection;
@@ -9,8 +11,6 @@ class FieldLayout extends Element
     protected FieldCollection $fields;
 
     protected array $items;
-
-    protected string $type;
 
     protected int $columns;
 
@@ -76,9 +76,8 @@ class FieldLayout extends Element
         13 => 'col-start-13',
     ];
 
-    public function __construct(string $type, FieldCollection $fields, array $options = [])
+    public function __construct(FieldCollection $fields, array $options = [])
     {
-        $this->type = $type;
         $this->fields = $fields;
         $this->items = array_values($options['items'] ?? []);
         $this->columns = $this->normalizeColumns($options['columns'] ?? $options['column'] ?? 1);

--- a/packages/preline-form/src/FieldCollection.php
+++ b/packages/preline-form/src/FieldCollection.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Str;
 use InvalidArgumentException;
 use Laravolt\Fields\Field;
 use Laravolt\PrelineForm\Contracts\HasFormOptions;
+use Laravolt\PrelineForm\Elements\FieldLayout;
 use Laravolt\PrelineForm\Elements\FormControl;
 use Laravolt\PrelineForm\Elements\Html;
 
@@ -65,6 +66,12 @@ class FieldCollection extends Collection
             }
         }
 
+        foreach ($this->items as $element) {
+            if (method_exists($element, 'bindValues')) {
+                $element->bindValues($values);
+            }
+        }
+
         return $this;
     }
 
@@ -75,6 +82,11 @@ class FieldCollection extends Collection
         $macro = false;
 
         switch ($type) {
+            case 'grid':
+            case 'row':
+                $element = new FieldLayout($type, new static($field['items'] ?? []), $field->toArray());
+                break;
+
             case 'color':
             case 'date':
             case 'email':

--- a/packages/preline-form/src/FieldCollection.php
+++ b/packages/preline-form/src/FieldCollection.php
@@ -84,7 +84,7 @@ class FieldCollection extends Collection
         switch ($type) {
             case 'grid':
             case 'row':
-                $element = new FieldLayout($type, new static($field['items'] ?? []), $field->toArray());
+                $element = new FieldLayout(new static($field['items'] ?? []), $field->toArray());
                 break;
 
             case 'color':

--- a/tests/Unit/PrelineForm/FieldCollectionLayoutTest.php
+++ b/tests/Unit/PrelineForm/FieldCollectionLayoutTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Laravolt\Tests\Unit\PrelineForm;
+
+use Laravolt\PrelineForm\ServiceProvider;
+use Laravolt\Tests\UnitTest;
+
+class FieldCollectionLayoutTest extends UnitTest
+{
+    protected function getPackageProviders($app)
+    {
+        return [
+            ServiceProvider::class,
+        ];
+    }
+
+    public function test_grid_layout_can_be_declared_from_field_collection_config()
+    {
+        $html = (string) form()->make([
+            [
+                'type' => 'grid',
+                'columns' => 3,
+                'gap' => 6,
+                'class' => 'items-start',
+                'items' => [
+                    ['type' => 'text', 'name' => 'first_name'],
+                    ['type' => 'email', 'name' => 'email', 'colSpan' => 2, 'colStart' => 2],
+                    ['type' => 'textarea', 'name' => 'bio', 'columnSpan' => 'full', 'layoutClass' => 'md:col-start-1'],
+                ],
+            ],
+        ]);
+
+        $this->assertStringContainsString('grid grid-cols-3 gap-6 items-start', $html);
+        $this->assertStringContainsString('class="col-span-1"', $html);
+        $this->assertStringContainsString('class="col-span-2 col-start-2"', $html);
+        $this->assertStringContainsString('class="col-span-full md:col-start-1"', $html);
+        $this->assertStringContainsString('name="first_name"', $html);
+        $this->assertStringContainsString('name="email"', $html);
+        $this->assertStringContainsString('name="bio"', $html);
+    }
+
+    public function test_row_layout_supports_nested_items_and_width_alias()
+    {
+        $html = (string) form()->make([
+            [
+                'type' => 'row',
+                'columns' => 4,
+                'items' => [
+                    ['type' => 'text', 'name' => 'title', 'width' => 3],
+                    [
+                        'type' => 'grid',
+                        'columns' => 2,
+                        'colSpan' => 1,
+                        'items' => [
+                            ['type' => 'text', 'name' => 'city'],
+                            ['type' => 'text', 'name' => 'postal_code'],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertStringContainsString('grid grid-cols-4 gap-4', $html);
+        $this->assertStringContainsString('class="col-span-3"', $html);
+        $this->assertStringContainsString('grid grid-cols-2 gap-4', $html);
+        $this->assertStringContainsString('name="city"', $html);
+        $this->assertStringContainsString('name="postal_code"', $html);
+    }
+
+    public function test_bind_values_reaches_fields_inside_layouts()
+    {
+        $fields = form()->make([
+            [
+                'type' => 'grid',
+                'columns' => 2,
+                'items' => [
+                    ['type' => 'text', 'name' => 'name'],
+                    ['type' => 'email', 'name' => 'email'],
+                ],
+            ],
+        ])->bindValues([
+            'name' => 'Rama',
+            'email' => 'rama@example.test',
+        ]);
+
+        $html = (string) $fields;
+
+        $this->assertStringContainsString('value="Rama"', $html);
+        $this->assertStringContainsString('value="rama@example.test"', $html);
+    }
+}

--- a/tests/Unit/PrelineForm/FieldCollectionLayoutTest.php
+++ b/tests/Unit/PrelineForm/FieldCollectionLayoutTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laravolt\Tests\Unit\PrelineForm;
 
 use Laravolt\PrelineForm\ServiceProvider;


### PR DESCRIPTION
## Summary
- Add declarative `grid` / `row` layouts to PrelineForm field config
- Support nested layout `items`, configurable columns/gap/classes, and per-field span/start positioning
- Add FieldCollection-level tests for layout rendering and recursive value binding

## Validation
- `php -l` passed for changed PHP files
- `git diff --check` passed
- `composer validate --working-dir=packages/preline-form --no-check-publish --no-interaction` passed

Full test suite was not run locally because this worktree has no `vendor/` directory.

Closes #182