### PR TITLE
fix(acl): force logout after role permission changes

### DIFF
--- a/src/Epicentrum/Repositories/EloquentRepository.php
+++ b/src/Epicentrum/Repositories/EloquentRepository.php
@@ -8,6 +8,8 @@ use Exception;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
+use Laravolt\Platform\Models\User;
+use Laravolt\Platform\Services\AccessControlInvalidator;
 
 /**
  * Class UserRepositoryEloquent.
@@ -15,7 +17,7 @@ use Illuminate\Support\Arr;
 class EloquentRepository implements RepositoryInterface
 {
     /**
-     * @var \Laravolt\Platform\Models\User
+     * @var User
      */
     protected $model;
 
@@ -77,10 +79,20 @@ class EloquentRepository implements RepositoryInterface
         $user->update($account);
 
         if (config('laravolt.epicentrum.role.editable')) {
-            $user->roles()->sync($roles);
+            $changes = $user->roles()->sync($roles);
+
+            if ($this->hasSyncChanges($changes)) {
+                $user->unsetRelation('roles');
+                app(AccessControlInvalidator::class)->invalidateUser($user);
+            }
         }
 
         return $user;
+    }
+
+    protected function hasSyncChanges(array $changes): bool
+    {
+        return collect($changes)->flatten()->isNotEmpty();
     }
 
     public function updatePassword($password, $id)

--- a/src/Platform/Concerns/HasRoleAndPermission.php
+++ b/src/Platform/Concerns/HasRoleAndPermission.php
@@ -6,13 +6,15 @@ namespace Laravolt\Platform\Concerns;
 
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Str;
 use Laravolt\Platform\Models\Permission;
+use Laravolt\Platform\Services\AccessControlInvalidator;
 
 trait HasRoleAndPermission
 {
-    public function roles(): \Illuminate\Database\Eloquent\Relations\BelongsToMany
+    public function roles(): BelongsToMany
     {
         return $this->belongsToMany(config('laravolt.epicentrum.models.role'), 'acl_role_user', 'user_id', 'role_id');
     }
@@ -46,38 +48,24 @@ trait HasRoleAndPermission
 
     public function assignRole($role): self
     {
-        if (is_array($role)) {
-            foreach ($role as $r) {
-                $this->assignRole($r);
-            }
+        $changes = $this->roles()->syncWithoutDetaching($this->resolveRoleIds($role, true));
 
-            return $this;
+        if ($this->hasSyncChanges($changes)) {
+            $this->unsetRelation('roles');
+            $this->invalidateAccessControl();
         }
-
-        if (is_string($role) && ! Str::isUuid($role)) {
-            $role = app(config('laravolt.epicentrum.models.role'))->firstOrCreate(['name' => $role]);
-        }
-
-        $this->roles()->syncWithoutDetaching($role);
 
         return $this;
     }
 
     public function revokeRole($role): self
     {
-        if (is_array($role)) {
-            foreach ($role as $r) {
-                $this->revokeRole($r);
-            }
+        $detached = $this->roles()->detach($this->resolveRoleIds($role));
 
-            return $this;
+        if ($detached > 0) {
+            $this->unsetRelation('roles');
+            $this->invalidateAccessControl();
         }
-
-        if (is_string($role) && ! Str::isUuid($role)) {
-            $role = app(config('laravolt.epicentrum.models.role'))->where('name', $role)->first();
-        }
-
-        $this->roles()->detach($role);
 
         return $this;
     }
@@ -121,43 +109,12 @@ trait HasRoleAndPermission
 
     public function syncRoles($roles): self
     {
-        $ids = collect($roles)->transform(
-            function ($role) {
-                if (is_numeric($role)) {
-                    return (int) $role;
-                }
+        $changes = $this->roles()->sync($this->resolveRoleIds($roles, true));
 
-                if (Str::isUuid($role)) {
-                    return $role;
-                }
-
-                if (is_string($role)) {
-                    $role = app(config('laravolt.epicentrum.models.role'))->firstOrCreate(['name' => $role]);
-
-                    return $role->getKey();
-                }
-
-                if ($role instanceof Model) {
-                    return $role->getKey();
-                }
-
-                return $role;
-            }
-        )->filter(
-            function ($id) {
-                if (is_int($id)) {
-                    return $id > 0;
-                }
-
-                if (is_string($id)) {
-                    return trim($id) !== '';
-                }
-
-                return false;
-            }
-        );
-
-        $this->roles()->sync($ids);
+        if ($this->hasSyncChanges($changes)) {
+            $this->unsetRelation('roles');
+            $this->invalidateAccessControl();
+        }
 
         return $this;
     }
@@ -171,6 +128,55 @@ trait HasRoleAndPermission
         );
 
         return $result;
+    }
+
+    protected function resolveRoleIds($roles, bool $createMissing = false): array
+    {
+        return collect(is_array($roles) ? $roles : [$roles])
+            ->map(function ($role) use ($createMissing) {
+                if (is_numeric($role)) {
+                    return (int) $role;
+                }
+
+                if (is_string($role) && Str::isUuid($role)) {
+                    return $role;
+                }
+
+                if (is_string($role)) {
+                    $query = app(config('laravolt.epicentrum.models.role'))->where('name', $role);
+                    $role = $createMissing ? $query->firstOrCreate(['name' => $role]) : $query->first();
+
+                    return $role?->getKey();
+                }
+
+                if ($role instanceof Model) {
+                    return $role->getKey();
+                }
+
+                return $role;
+            })
+            ->filter(function ($id) {
+                if (is_int($id)) {
+                    return $id > 0;
+                }
+
+                if (is_string($id)) {
+                    return trim($id) !== '';
+                }
+
+                return false;
+            })
+            ->all();
+    }
+
+    protected function hasSyncChanges(array $changes): bool
+    {
+        return collect($changes)->flatten()->isNotEmpty();
+    }
+
+    protected function invalidateAccessControl(): void
+    {
+        app(AccessControlInvalidator::class)->invalidateUser($this);
     }
 
     protected function _hasPermission($permission, $checkAll = false): bool

--- a/src/Platform/Models/Role.php
+++ b/src/Platform/Models/Role.php
@@ -6,6 +6,8 @@ namespace Laravolt\Platform\Models;
 
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
+use Laravolt\Platform\Services\AccessControlInvalidator;
 
 class Role extends Model
 {
@@ -34,6 +36,8 @@ class Role extends Model
         }
 
         $this->permissions()->attach($permission);
+        $this->unsetRelation('permissions');
+        $this->invalidateAssignedUsersAccessControl();
 
         return $this;
     }
@@ -45,6 +49,8 @@ class Role extends Model
         }
 
         $this->permissions()->detach($permission);
+        $this->unsetRelation('permissions');
+        $this->invalidateAssignedUsersAccessControl();
 
         return $this;
     }
@@ -59,8 +65,8 @@ class Role extends Model
     public function syncPermission(array $permissions)
     {
         $ids = collect($permissions)->transform(function ($permission) {
-            if (str($permission)->isUlid()) {
-                return (string) $permission;
+            if (is_string($permission) && str($permission)->isUlid()) {
+                return $permission;
             }
             if (is_numeric($permission)) {
                 return (int) $permission;
@@ -74,10 +80,35 @@ class Role extends Model
                 return $permission->getKey();
             }
         })->filter(function ($id) {
-            return $id > 0;
+            if (is_int($id)) {
+                return $id > 0;
+            }
+
+            if (is_string($id)) {
+                return trim($id) !== '';
+            }
+
+            return false;
         });
 
-        return $this->permissions()->sync($ids->toArray());
+        $changes = $this->permissions()->sync($ids->toArray());
+
+        if ($this->hasSyncChanges($changes)) {
+            $this->unsetRelation('permissions');
+            $this->invalidateAssignedUsersAccessControl();
+        }
+
+        return $changes;
+    }
+
+    protected function hasSyncChanges(array $changes): bool
+    {
+        return collect($changes)->flatten()->isNotEmpty();
+    }
+
+    protected function invalidateAssignedUsersAccessControl(): void
+    {
+        app(AccessControlInvalidator::class)->invalidateUsers($this->users()->cursor());
     }
 
     protected function _hasPermission($permission)
@@ -96,7 +127,7 @@ class Role extends Model
             if (is_string($permission)) {
                 $permissionModel = app(config('laravolt.epicentrum.models.permission'));
                 $keyType = $permissionModel->getKeyType();
-                if ($keyType === 'string' && \Illuminate\Support\Str::isUlid($permission)) {
+                if ($keyType === 'string' && Str::isUlid($permission)) {
                     // Try to match key first, fallback to name
                     return $this->permissions->containsStrict($permissionModel->getKeyName(), $permission)
                         || $this->permissions->containsStrict('name', $permission);

--- a/src/Platform/Services/AccessControlInvalidator.php
+++ b/src/Platform/Services/AccessControlInvalidator.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravolt\Platform\Services;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Throwable;
+
+class AccessControlInvalidator
+{
+    public function invalidateUser(Model $user): void
+    {
+        $userId = $user->getKey();
+
+        Cache::forget("users.{$userId}.permissions");
+        $this->deleteDatabaseSessions($userId);
+    }
+
+    public function invalidateUsers(iterable $users): void
+    {
+        foreach ($users as $user) {
+            if ($user instanceof Model) {
+                $this->invalidateUser($user);
+            }
+        }
+    }
+
+    protected function deleteDatabaseSessions(mixed $userId): void
+    {
+        try {
+            $connection = config('session.connection');
+            $table = config('session.table', 'sessions');
+            $schema = Schema::connection($connection);
+
+            if (! $schema->hasTable($table) || ! $schema->hasColumn($table, 'user_id')) {
+                return;
+            }
+
+            DB::connection($connection)->table($table)->where('user_id', $userId)->delete();
+        } catch (Throwable) {
+            // Session invalidation is best-effort because Laravolt can run with
+            // non-database session drivers or applications without session table.
+        }
+    }
+}

--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -4,6 +4,12 @@ declare(strict_types=1);
 
 namespace Laravolt\Tests;
 
+use Akaunting\Setting\Provider;
+use Anhskohbo\NoCaptcha\NoCaptchaServiceProvider;
+use Illuminate\Foundation\Application;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
 use Laravolt\Platform\Models\User;
 use Laravolt\Platform\Providers\EpicentrumServiceProvider;
 use Laravolt\Platform\Providers\PlatformServiceProvider;
@@ -28,7 +34,7 @@ trait Bootstrap
     }
 
     /**
-     * @param  \Illuminate\Foundation\Application  $app
+     * @param  Application  $app
      */
     protected function getEnvironmentSetUp($app)
     {
@@ -42,7 +48,7 @@ trait Bootstrap
     }
 
     /**
-     * @param  \Illuminate\Foundation\Application  $app
+     * @param  Application  $app
      * @return array
      */
     protected function getPackageProviders($app)
@@ -53,18 +59,18 @@ trait Bootstrap
             PlatformServiceProvider::class,
             UiServiceProvider::class,
             LivewireServiceProvider::class,
-            \Akaunting\Setting\Provider::class,
+            Provider::class,
         ];
 
         if (class_exists('Anhskohbo\NoCaptcha\NoCaptchaServiceProvider')) {
-            $providers[] = \Anhskohbo\NoCaptcha\NoCaptchaServiceProvider::class;
+            $providers[] = NoCaptchaServiceProvider::class;
         }
 
         return $providers;
     }
 
     /**
-     * @param  \Illuminate\Foundation\Application  $app
+     * @param  Application  $app
      * @return array
      */
     protected function getPackageAliases($app)
@@ -80,5 +86,30 @@ trait Bootstrap
             'email' => 'fulan@example.com',
             'password' => bcrypt('secret'),
         ]);
+    }
+
+    protected function createSessionFor(User $user): void
+    {
+        Cache::put("users.{$user->getKey()}.permissions", collect(['stale']), 3600);
+        DB::table('sessions')->insert([
+            'id' => (string) Str::ulid(),
+            'user_id' => $user->getKey(),
+            'ip_address' => '127.0.0.1',
+            'user_agent' => 'PHPUnit',
+            'payload' => 'payload',
+            'last_activity' => (string) Str::ulid(),
+        ]);
+    }
+
+    protected function assertAccessControlInvalidatedFor(User $user): void
+    {
+        $this->assertFalse(Cache::has("users.{$user->getKey()}.permissions"));
+        $this->assertDatabaseMissing('sessions', ['user_id' => $user->getKey()]);
+    }
+
+    protected function assertAccessControlStillValidFor(User $user): void
+    {
+        $this->assertTrue(Cache::has("users.{$user->getKey()}.permissions"));
+        $this->assertDatabaseHas('sessions', ['user_id' => $user->getKey()]);
     }
 }

--- a/tests/Feature/Acl/HasRoleAndPermissionTest.php
+++ b/tests/Feature/Acl/HasRoleAndPermissionTest.php
@@ -6,6 +6,7 @@ namespace Laravolt\Tests\Feature\Acl;
 
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravolt\Epicentrum\Repositories\EloquentRepository;
 use Laravolt\Tests\FeatureTest;
 
 class HasRoleAndPermissionTest extends FeatureTest
@@ -133,6 +134,42 @@ class HasRoleAndPermissionTest extends FeatureTest
         $user->syncRoles([1, $operator, 'Staff']);
 
         $this->assertSame(3, $user->roles->count());
+    }
+
+    public function test_sync_roles_invalidates_user_permission_cache_and_sessions()
+    {
+        $user = $this->createUser();
+        $operator = app(config('laravolt.epicentrum.models.role'))->create(['name' => 'Operator']);
+        $this->createSessionFor($user);
+
+        $user->syncRoles([$operator]);
+
+        $this->assertAccessControlInvalidatedFor($user);
+    }
+
+    public function test_repository_role_update_invalidates_user_permission_cache_and_sessions()
+    {
+        config(['laravolt.epicentrum.role.editable' => true]);
+        $user = $this->createUser();
+        $operator = app(config('laravolt.epicentrum.models.role'))->create(['name' => 'Operator']);
+        $this->createSessionFor($user);
+
+        app(EloquentRepository::class)->updateAccount($user->getKey(), ['name' => 'Fulan Updated'], [$operator->getKey()]);
+
+        $this->assertAccessControlInvalidatedFor($user);
+    }
+
+    public function test_repository_role_update_keeps_sessions_when_roles_do_not_change()
+    {
+        config(['laravolt.epicentrum.role.editable' => true]);
+        $user = $this->createUser();
+        $operator = app(config('laravolt.epicentrum.models.role'))->create(['name' => 'Operator']);
+        $user->assignRole($operator);
+        $this->createSessionFor($user);
+
+        app(EloquentRepository::class)->updateAccount($user->getKey(), ['name' => 'Fulan Updated'], [$operator->getKey()]);
+
+        $this->assertAccessControlStillValidFor($user);
     }
 
     public function test_has_permission()

--- a/tests/Feature/Acl/Models/RoleTest.php
+++ b/tests/Feature/Acl/Models/RoleTest.php
@@ -133,4 +133,30 @@ class RoleTest extends FeatureTest
 
         $this->assertCount(4, $role->permissions);
     }
+
+    public function test_sync_permission_invalidates_assigned_users_permission_cache_and_sessions()
+    {
+        $role = app(config('laravolt.epicentrum.models.role'))->create(['name' => 'Admin']);
+        $user = $this->createUser();
+        $user->assignRole($role);
+        $this->createSessionFor($user);
+
+        $role->syncPermission(['create']);
+
+        $this->assertAccessControlInvalidatedFor($user);
+    }
+
+    public function test_sync_permission_keeps_sessions_when_permissions_do_not_change()
+    {
+        $role = app(config('laravolt.epicentrum.models.role'))->create(['name' => 'Admin']);
+        $permission = app(config('laravolt.epicentrum.models.permission'))->create(['name' => 'create']);
+        $role->syncPermission([$permission]);
+        $user = $this->createUser();
+        $user->assignRole($role);
+        $this->createSessionFor($user);
+
+        $role->syncPermission([$permission]);
+
+        $this->assertAccessControlStillValidFor($user);
+    }
 }


### PR DESCRIPTION
## Summary
- invalidate cached user permissions when roles are assigned, revoked, or synced
- invalidate affected users when role permissions are changed
- delete database-backed sessions for affected users so permission changes force re-authentication
- cover direct user role updates and repository-driven account role updates

Fixes #273.

## Tests
- `php -l` on changed PHP files
- `vendor/bin/pint --test` on changed PHP files
- `composer validate --no-check-publish --no-interaction`

Note: direct package PHPUnit run is currently blocked locally by the existing `phpunit.xml.example` PostgreSQL test DSN (`127.0.0.1:5414`) / sqlite duplicate users-table setup, so I added targeted regression coverage and left CI to run against the project workflow.