### PR TITLE
⚡ Bolt: Optimize N+1 query in Role::syncPermission()

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,6 @@
 ## 2024-05-11 - Optimized Permission Check
 **Learning:** Laravolt's `HasRoleAndPermission` and `Role` models do dynamic query checks or `contains` lookups when `hasPermission` is called. Since permissions are eager-loaded, doing a `contains` operation manually can bypass `app(config(...))` overhead and Model instantiation.
 **Action:** Overrode `_hasPermission` in models to utilize eager-loaded relations properly.
+## 2024-05-13 - [Optimize N+1 query in Role syncPermission]
+**Learning:** When assigning permissions by an array of string names using a map/transform loop, doing a `firstOrCreate` on every item leads to an N+1 query problem, which is especially noticeable when assigning many permissions at once.
+**Action:** Always pre-fetch the existing records in bulk using `whereIn` and array difference functions (`array_diff`), then only run `firstOrCreate` on the truly missing items, and combine the IDs together.

--- a/src/Platform/Models/Role.php
+++ b/src/Platform/Models/Role.php
@@ -64,22 +64,45 @@ class Role extends Model
 
     public function syncPermission(array $permissions)
     {
-        $ids = collect($permissions)->transform(function ($permission) {
-            if (is_string($permission) && str($permission)->isUlid()) {
-                return $permission;
-            }
-            if (is_numeric($permission)) {
-                return (int) $permission;
-            }
-            if (is_string($permission)) {
-                $permissionObject = app(config('laravolt.epicentrum.models.permission'))->firstOrCreate(['name' => $permission]);
+        $ids = collect();
+        $stringNames = [];
 
-                return $permissionObject->getKey();
+        foreach ($permissions as $permission) {
+            if (is_string($permission) && str($permission)->isUlid()) {
+                $ids->push($permission);
+            } elseif (is_numeric($permission)) {
+                $ids->push((int) $permission);
+            } elseif (is_string($permission)) {
+                $stringNames[] = trim($permission);
+            } elseif ($permission instanceof Model) {
+                $ids->push($permission->getKey());
             }
-            if ($permission instanceof Model) {
-                return $permission->getKey();
+        }
+
+        $stringNames = array_filter($stringNames, fn ($name) => $name !== '');
+
+        if (! empty($stringNames)) {
+            $permissionModel = app(config('laravolt.epicentrum.models.permission'));
+
+            // ⚡ Bolt: Prevent N+1 query when assigning permissions by name
+            // Bulk fetch all existing string permissions via a single whereIn query
+            // and only execute firstOrCreate() for the missing names
+            $existingPermissions = $permissionModel->whereIn('name', $stringNames)->get();
+            $existingNames = $existingPermissions->pluck('name')->toArray();
+
+            foreach ($existingPermissions as $permission) {
+                $ids->push($permission->getKey());
             }
-        })->filter(function ($id) {
+
+            $missingNames = array_diff($stringNames, $existingNames);
+
+            foreach ($missingNames as $missingName) {
+                $newPermission = $permissionModel->firstOrCreate(['name' => $missingName]);
+                $ids->push($newPermission->getKey());
+            }
+        }
+
+        $ids = $ids->filter(function ($id) {
             if (is_int($id)) {
                 return $id > 0;
             }


### PR DESCRIPTION
💡 What: Replaced the looped `firstOrCreate` call inside `Role::syncPermission` with a bulk `whereIn` fetch for existing string permissions, and only calling `firstOrCreate` for missing ones.
🎯 Why: Iterating over an array of permission names and fetching/creating them one-by-one results in an N+1 query problem, which severely impacts database performance when syncing many permissions at once.
📊 Impact: Reduces database queries from O(N) to O(1) for existing permissions and O(M) for creating missing ones (where M is the subset of new permissions).
🔬 Measurement: Verify via Laravel Debugbar or Telescope that the number of `SELECT` and `INSERT` queries is significantly reduced when calling `$role->syncPermission(['create', 'read', 'update', 'delete', ...])`.

---
*PR created automatically by Jules for task [6954418995261356738](https://jules.google.com/task/6954418995261356738) started by @qisthidev*