### PR TITLE
⚡ Bolt: Optimize N+1 queries in role and permission assignments

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,6 @@
 ## 2024-05-11 - Optimized Permission Check
 **Learning:** Laravolt's `HasRoleAndPermission` and `Role` models do dynamic query checks or `contains` lookups when `hasPermission` is called. Since permissions are eager-loaded, doing a `contains` operation manually can bypass `app(config(...))` overhead and Model instantiation.
 **Action:** Overrode `_hasPermission` in models to utilize eager-loaded relations properly.
+## 2025-02-12 - Optimized N+1 Query in Role and Permission Assignments
+**Learning:** In Laravolt Platform, syncing arrays of new string permissions or roles via `syncPermission` and `assignRole`/`syncRoles` triggers individual `firstOrCreate` or `where(...)->first()` database queries for each string element, causing an N+1 query performance hit.
+**Action:** Implemented a bulk `whereIn` lookup to fetch all existing role/permission names before mapping over the list. Retrieved records are cached in a Collection and checked in memory, deferring to `firstOrCreate` only for completely new entries, dropping DB queries from O(N) to O(1) for existing entities.

--- a/src/Platform/Concerns/HasRoleAndPermission.php
+++ b/src/Platform/Concerns/HasRoleAndPermission.php
@@ -132,8 +132,23 @@ trait HasRoleAndPermission
 
     protected function resolveRoleIds($roles, bool $createMissing = false): array
     {
-        return collect(is_array($roles) ? $roles : [$roles])
-            ->map(function ($role) use ($createMissing) {
+        $rolesCollection = collect(is_array($roles) ? $roles : [$roles]);
+
+        // ⚡ Bolt: Bulk lookup string roles to avoid N+1 queries
+        $stringRoles = $rolesCollection->filter(function ($role) {
+            return is_string($role) && ! Str::isUuid($role);
+        })->unique()->values();
+
+        $existingRoles = collect();
+        if ($stringRoles->isNotEmpty()) {
+            $existingRoles = app(config('laravolt.epicentrum.models.role'))
+                ->whereIn('name', $stringRoles)
+                ->get()
+                ->keyBy('name');
+        }
+
+        return $rolesCollection
+            ->map(function ($role) use ($createMissing, $existingRoles) {
                 if (is_numeric($role)) {
                     return (int) $role;
                 }
@@ -143,10 +158,14 @@ trait HasRoleAndPermission
                 }
 
                 if (is_string($role)) {
-                    $query = app(config('laravolt.epicentrum.models.role'))->where('name', $role);
-                    $role = $createMissing ? $query->firstOrCreate(['name' => $role]) : $query->first();
+                    $foundRole = $existingRoles->get($role);
 
-                    return $role?->getKey();
+                    if (! $foundRole && $createMissing) {
+                        $foundRole = app(config('laravolt.epicentrum.models.role'))->firstOrCreate(['name' => $role]);
+                        $existingRoles->put($role, $foundRole);
+                    }
+
+                    return $foundRole?->getKey();
                 }
 
                 if ($role instanceof Model) {

--- a/src/Platform/Models/Role.php
+++ b/src/Platform/Models/Role.php
@@ -64,7 +64,22 @@ class Role extends Model
 
     public function syncPermission(array $permissions)
     {
-        $ids = collect($permissions)->transform(function ($permission) {
+        $permissionsCollection = collect($permissions);
+
+        // ⚡ Bolt: Bulk lookup string permissions to avoid N+1 queries
+        $stringPermissions = $permissionsCollection->filter(function ($permission) {
+            return is_string($permission) && ! str($permission)->isUlid() && ! is_numeric($permission);
+        })->unique()->values();
+
+        $existingPermissions = collect();
+        if ($stringPermissions->isNotEmpty()) {
+            $existingPermissions = app(config('laravolt.epicentrum.models.permission'))
+                ->whereIn('name', $stringPermissions)
+                ->get()
+                ->keyBy('name');
+        }
+
+        $ids = $permissionsCollection->transform(function ($permission) use ($existingPermissions) {
             if (is_string($permission) && str($permission)->isUlid()) {
                 return $permission;
             }
@@ -72,7 +87,12 @@ class Role extends Model
                 return (int) $permission;
             }
             if (is_string($permission)) {
-                $permissionObject = app(config('laravolt.epicentrum.models.permission'))->firstOrCreate(['name' => $permission]);
+                $permissionObject = $existingPermissions->get($permission);
+
+                if (! $permissionObject) {
+                    $permissionObject = app(config('laravolt.epicentrum.models.permission'))->firstOrCreate(['name' => $permission]);
+                    $existingPermissions->put($permission, $permissionObject);
+                }
 
                 return $permissionObject->getKey();
             }


### PR DESCRIPTION
💡 What: Refactored `resolveRoleIds` in `HasRoleAndPermission` trait and `syncPermission` in `Role` model to perform a single bulk database query (`whereIn`) for fetching existing entities by name before iteration.
🎯 Why: Prevents N+1 database queries from being fired inside mapping loops when assigning multiple string permissions or roles to models via `syncPermissions` or `assignRole`.
📊 Impact: Decreases database queries from O(N) to O(1) for assignments involving existing roles or permissions, substantially reducing connection overhead on heavy bulk sync operations.
🔬 Measurement: Verify by executing feature tests. The underlying `sync` and cache invalidation behaviors are exactly preserved.

---
*PR created automatically by Jules for task [15501898127364968494](https://jules.google.com/task/15501898127364968494) started by @qisthidev*