### PR TITLE
⚡ Bolt: Optimize bulk session invalidation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,6 @@
 ## 2024-05-11 - Optimized Permission Check
 **Learning:** Laravolt's `HasRoleAndPermission` and `Role` models do dynamic query checks or `contains` lookups when `hasPermission` is called. Since permissions are eager-loaded, doing a `contains` operation manually can bypass `app(config(...))` overhead and Model instantiation.
 **Action:** Overrode `_hasPermission` in models to utilize eager-loaded relations properly.
+## 2024-05-17 - Optimize Bulk Session Invalidation
+**Learning:** In Laravolt, invalidating multiple users at once via `AccessControlInvalidator::invalidateUsers` originally called `invalidateUser` iteratively. This resulted in an N+1 query issue for deleting database sessions, while caching must still be done iteratively.
+**Action:** Extract the target IDs into an array during iteration to clear cache sequentially, then execute a single `whereIn()->delete()` query on the session table to optimize database interaction.

--- a/src/Platform/Services/AccessControlInvalidator.php
+++ b/src/Platform/Services/AccessControlInvalidator.php
@@ -16,20 +16,34 @@ class AccessControlInvalidator
     {
         $userId = $user->getKey();
 
-        Cache::forget("users.{$userId}.permissions");
+        $this->invalidateUserCache($userId);
         $this->deleteDatabaseSessions($userId);
     }
 
     public function invalidateUsers(iterable $users): void
     {
+        $userIds = [];
+
         foreach ($users as $user) {
             if ($user instanceof Model) {
-                $this->invalidateUser($user);
+                // Invalidate cache immediately for each user
+                $userId = $user->getKey();
+                $this->invalidateUserCache($userId);
+                $userIds[] = $userId;
             }
+        }
+
+        if (!empty($userIds)) {
+            $this->deleteDatabaseSessions($userIds);
         }
     }
 
-    protected function deleteDatabaseSessions(mixed $userId): void
+    protected function invalidateUserCache(mixed $userId): void
+    {
+        Cache::forget("users.{$userId}.permissions");
+    }
+
+    protected function deleteDatabaseSessions(mixed $userIds): void
     {
         try {
             $connection = config('session.connection');
@@ -40,7 +54,14 @@ class AccessControlInvalidator
                 return;
             }
 
-            DB::connection($connection)->table($table)->where('user_id', $userId)->delete();
+            $query = DB::connection($connection)->table($table);
+
+            // ⚡ Bolt: Fast-path for bulk database session deletion
+            if (is_array($userIds)) {
+                $query->whereIn('user_id', $userIds)->delete();
+            } else {
+                $query->where('user_id', $userIds)->delete();
+            }
         } catch (Throwable) {
             // Session invalidation is best-effort because Laravolt can run with
             // non-database session drivers or applications without session table.


### PR DESCRIPTION
💡 What: Refactored `AccessControlInvalidator::invalidateUsers` to gather user IDs and perform a single `whereIn` deletion for database sessions instead of executing a delete query per user.
🎯 Why: Calling `deleteDatabaseSessions` inside a loop created an N+1 query problem, slowing down bulk permission updates.
📊 Impact: Reduces O(N) session deletion queries to O(1), improving database performance when assigning/removing roles to multiple users.
🔬 Measurement: Verify by executing `invalidateUsers` with an array of users while inspecting the generated SQL queries using Laravel Debugbar or Telescope.

---
*PR created automatically by Jules for task [2767854643279882573](https://jules.google.com/task/2767854643279882573) started by @qisthidev*