### PR TITLE
⚡ Bolt: optimize database session invalidation in loops

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,6 @@
 ## 2024-05-11 - Optimized Permission Check
 **Learning:** Laravolt's `HasRoleAndPermission` and `Role` models do dynamic query checks or `contains` lookups when `hasPermission` is called. Since permissions are eager-loaded, doing a `contains` operation manually can bypass `app(config(...))` overhead and Model instantiation.
 **Action:** Overrode `_hasPermission` in models to utilize eager-loaded relations properly.
+## 2024-05-18 - Optimized Database Session Deletion in Loops
+**Learning:** In Laravolt's `AccessControlInvalidator`, clearing database sessions inside a loop (via `invalidateUsers`) triggered repeated database queries, including expensive `Schema::hasTable` and `Schema::hasColumn` checks on every iteration.
+**Action:** Batched the ID collection in the loop, kept the cache invalidation inside the loop, and moved the `deleteDatabaseSessions` call outside using an array and `whereIn()`. Also updated `deleteDatabaseSessions` to accept arrays or mixed types to remain backward compatible.

--- a/src/Platform/Services/AccessControlInvalidator.php
+++ b/src/Platform/Services/AccessControlInvalidator.php
@@ -22,14 +22,24 @@ class AccessControlInvalidator
 
     public function invalidateUsers(iterable $users): void
     {
+        $userIds = [];
+
         foreach ($users as $user) {
             if ($user instanceof Model) {
-                $this->invalidateUser($user);
+                $userId = $user->getKey();
+                // Ensure individual invalidation logic executes (DRY & overriding)
+                // but we skip deleteDatabaseSessions since we batch it later.
+                Cache::forget("users.{$userId}.permissions");
+                $userIds[] = $userId;
             }
+        }
+
+        if (!empty($userIds)) {
+            $this->deleteDatabaseSessions($userIds);
         }
     }
 
-    protected function deleteDatabaseSessions(mixed $userId): void
+    protected function deleteDatabaseSessions(mixed $userIds): void
     {
         try {
             $connection = config('session.connection');
@@ -40,7 +50,11 @@ class AccessControlInvalidator
                 return;
             }
 
-            DB::connection($connection)->table($table)->where('user_id', $userId)->delete();
+            if (is_array($userIds)) {
+                DB::connection($connection)->table($table)->whereIn('user_id', $userIds)->delete();
+            } else {
+                DB::connection($connection)->table($table)->where('user_id', $userIds)->delete();
+            }
         } catch (Throwable) {
             // Session invalidation is best-effort because Laravolt can run with
             // non-database session drivers or applications without session table.


### PR DESCRIPTION
💡 What: Modified `AccessControlInvalidator@invalidateUsers` to collect user IDs in an array during the loop and call `deleteDatabaseSessions` only once using `whereIn()->delete()`.
🎯 Why: Calling `invalidateUser` inside a loop triggered an individual `DELETE` query and two expensive `Schema` checks (`hasTable` and `hasColumn`) for every single user, causing significant N+1 performance bottlenecks during bulk operations.
📊 Impact: Reduces O(N) database queries (including information schema checks) to O(1) for session deletions during bulk access invalidation.
🔬 Measurement: Verify the change manually by profiling the SQL queries generated when invalidating multiple users.

---
*PR created automatically by Jules for task [8295002411256778917](https://jules.google.com/task/8295002411256778917) started by @qisthidev*