### PR TITLE
⚡ Bolt: optimize syncPermission and role resolution N+1 bottlenecks

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,6 @@
 ## 2024-05-11 - Optimized Permission Check
 **Learning:** Laravolt's `HasRoleAndPermission` and `Role` models do dynamic query checks or `contains` lookups when `hasPermission` is called. Since permissions are eager-loaded, doing a `contains` operation manually can bypass `app(config(...))` overhead and Model instantiation.
 **Action:** Overrode `_hasPermission` in models to utilize eager-loaded relations properly.
+## 2024-05-20 - Optimized Role/Permission String Syncing
+**Learning:** `firstOrCreate` in loops (like in `syncPermission` and `resolveRoleIds`) creates massive N+1 query bottlenecks when resolving string arrays to database IDs.
+**Action:** Always extract string names first, perform a bulk `whereIn('name', $names)->get()` to fetch existing models, and only loop and `firstOrCreate` for the missing string names.

--- a/src/Platform/Concerns/HasRoleAndPermission.php
+++ b/src/Platform/Concerns/HasRoleAndPermission.php
@@ -187,8 +187,33 @@ trait HasRoleAndPermission
 
     protected function resolveRoleIds($roles, bool $createMissing = false): array
     {
-        return collect(is_array($roles) ? $roles : [$roles])
-            ->map(function ($role) use ($createMissing) {
+        $rolesArray = is_array($roles) ? $roles : [$roles];
+
+        // ⚡ Bolt: Extract string names to bulk query and avoid N+1 firstOrCreate queries
+        $stringNames = [];
+        foreach ($rolesArray as $role) {
+            if (is_string($role) && !Str::isUuid($role) && !is_numeric($role)) {
+                $stringNames[] = $role;
+            }
+        }
+
+        $resolvedStringIds = [];
+        if (!empty($stringNames)) {
+            $roleModel = app(config('laravolt.epicentrum.models.role'));
+            $existingRoles = $roleModel->whereIn('name', $stringNames)->get()->keyBy('name');
+
+            foreach ($stringNames as $name) {
+                if ($existingRoles->has($name)) {
+                    $resolvedStringIds[$name] = $existingRoles->get($name)->getKey();
+                } elseif ($createMissing) {
+                    $newRole = $roleModel->firstOrCreate(['name' => $name]);
+                    $resolvedStringIds[$name] = $newRole->getKey();
+                }
+            }
+        }
+
+        return collect($rolesArray)
+            ->map(function ($role) use ($resolvedStringIds) {
                 if (is_numeric($role)) {
                     return (int) $role;
                 }
@@ -198,10 +223,7 @@ trait HasRoleAndPermission
                 }
 
                 if (is_string($role)) {
-                    $query = app(config('laravolt.epicentrum.models.role'))->where('name', $role);
-                    $role = $createMissing ? $query->firstOrCreate(['name' => $role]) : $query->first();
-
-                    return $role?->getKey();
+                    return $resolvedStringIds[$role] ?? null;
                 }
 
                 if ($role instanceof Model) {

--- a/src/Platform/Models/Role.php
+++ b/src/Platform/Models/Role.php
@@ -64,7 +64,30 @@ class Role extends Model
 
     public function syncPermission(array $permissions)
     {
-        $ids = collect($permissions)->transform(function ($permission) {
+        // ⚡ Bolt: Extract string names to bulk query and avoid N+1 firstOrCreate queries
+        $stringNames = [];
+        foreach ($permissions as $permission) {
+            if (is_string($permission) && !str($permission)->isUlid() && !is_numeric($permission)) {
+                $stringNames[] = $permission;
+            }
+        }
+
+        $resolvedStringIds = [];
+        if (!empty($stringNames)) {
+            $permissionModel = app(config('laravolt.epicentrum.models.permission'));
+            $existingPermissions = $permissionModel->whereIn('name', $stringNames)->get()->keyBy('name');
+
+            foreach ($stringNames as $name) {
+                if ($existingPermissions->has($name)) {
+                    $resolvedStringIds[$name] = $existingPermissions->get($name)->getKey();
+                } else {
+                    $newPermission = $permissionModel->firstOrCreate(['name' => $name]);
+                    $resolvedStringIds[$name] = $newPermission->getKey();
+                }
+            }
+        }
+
+        $ids = collect($permissions)->transform(function ($permission) use ($resolvedStringIds) {
             if (is_string($permission) && str($permission)->isUlid()) {
                 return $permission;
             }
@@ -72,9 +95,7 @@ class Role extends Model
                 return (int) $permission;
             }
             if (is_string($permission)) {
-                $permissionObject = app(config('laravolt.epicentrum.models.permission'))->firstOrCreate(['name' => $permission]);
-
-                return $permissionObject->getKey();
+                return $resolvedStringIds[$permission] ?? null;
             }
             if ($permission instanceof Model) {
                 return $permission->getKey();


### PR DESCRIPTION
💡 What: Replaced individual `firstOrCreate` calls within `map` loops with an upfront bulk `whereIn('name', $names)` fetch for both `syncPermission` (in `Role.php`) and `resolveRoleIds` (in `HasRoleAndPermission.php`). Missing records are still seamlessly created.

🎯 Why: In Laravolt, synchronizing permissions and roles frequently passes arrays of strings. The previous implementation executed `firstOrCreate` for every single string in the loop, creating a significant N+1 query performance bottleneck during role provisioning or authentication flows.

📊 Impact: Reduces database queries from O(N) to O(1) for existing records and O(K) (where K is the number of missing/new records). For a sync payload with 10 existing permissions, it reduces the query load from 11 queries to 2.

🔬 Measurement: Verify locally via DB::getQueryLog() when executing `$role->syncPermission(['perm1', 'perm2', 'perm3'])`. Previously ~10 queries, now just ~4 (1 fetch + 3 insert).

---
*PR created automatically by Jules for task [3963575217175639945](https://jules.google.com/task/3963575217175639945) started by @qisthidev*