### PR TITLE
⚡ Bolt: bulk update permissions in epicentrum

### DIFF
--- a/src/Epicentrum/Http/Controllers/PermissionController.php
+++ b/src/Epicentrum/Http/Controllers/PermissionController.php
@@ -10,17 +10,61 @@ class PermissionController extends Controller
 {
     public function edit()
     {
-        $permissions = config('laravolt.epicentrum.models.permission')::all()->sortBy(function ($item) {
-            return mb_strtolower($item->name);
-        });
+        $permissions = config('laravolt.epicentrum.models.permission')::all()->sortBy(
+            function ($item) {
+                return mb_strtolower($item->name);
+            }
+        );
 
         return view('laravolt::permissions.edit', compact('permissions'));
     }
 
     public function update()
     {
-        foreach (request('permission', []) as $key => $description) {
-            config('laravolt.epicentrum.models.permission')::whereId($key)->update(['description' => $description]);
+        $permissions = request('permission', []);
+
+        if (! empty($permissions)) {
+            $modelClass = config('laravolt.epicentrum.models.permission');
+            $model = new $modelClass();
+            $connection = $model->getConnectionName() ?: config('database.default');
+
+            // ⚡ Bolt: Optimizing O(N) queries to O(1) by batching with CASE statement
+            // We chunk in case of numerous permissions to avoid database driver parameter limits
+            foreach (array_chunk($permissions, 300, true) as $chunk) {
+                $cases = [];
+                $params = [];
+                $ids = [];
+
+                $keyName = $model->getKeyName();
+
+                foreach ($chunk as $key => $description) {
+                    $cases[] = "WHEN {$keyName} = ? THEN ?";
+                    $params[] = $key;
+                    $params[] = $description;
+                    $ids[] = $key;
+                }
+
+                $hasTimestamps = $model->usesTimestamps();
+                if ($hasTimestamps) {
+                    $params[] = now(); // For updated_at
+                }
+
+                $idsString = implode(',', array_fill(0, count($ids), '?'));
+                $params = array_merge($params, $ids);
+
+                $casesSql = implode(' ', $cases);
+
+                $grammar = $model->getConnection()->getQueryGrammar();
+                $wrappedTable = $grammar->wrapTable($model->getTable());
+                $wrappedDescription = $grammar->wrap('description');
+                $wrappedKey = $grammar->wrap($keyName);
+
+                $setUpdatedAt = $hasTimestamps ? ", {$grammar->wrap($model->getUpdatedAtColumn())} = ?" : '';
+
+                $sql = "UPDATE {$wrappedTable} SET {$wrappedDescription} = CASE {$casesSql} ELSE {$wrappedDescription} END{$setUpdatedAt} WHERE {$wrappedKey} IN ({$idsString})";
+
+                \Illuminate\Support\Facades\DB::connection($connection)->update($sql, $params);
+            }
         }
 
         return redirect()->back()->withSuccess('Permission updated');


### PR DESCRIPTION
💡 What
Refactored the `update` method in `Laravolt\Epicentrum\Http\Controllers\PermissionController` to replace a `foreach` loop that performed individual model updates with a single, chunked raw SQL `UPDATE` statement using a `CASE` expression.

🎯 Why
When an administrator edits permissions via the Epicentrum UI, the previous implementation fired an individual `UPDATE` query for every permission being saved, leading to an N+1 query issue (e.g., 50 permissions = 50 queries). This caused unnecessary latency and database load during a simple form submission.

📊 Impact
Reduces database round-trips from O(N) to O(1) for saving permissions. A payload of 50 updated permissions will now execute 1 query instead of 50. Parameter limits are respected by chunking the request array, ensuring safe scaling regardless of the database driver.

🔬 Measurement
Review the queries fired during a permissions save operation in the Laravel Debugbar or Telescope. The previous multiple `update permissions set...` queries will be replaced by a single `update permissions set description = case when...` statement.

---
*PR created automatically by Jules for task [7055342807384320894](https://jules.google.com/task/7055342807384320894) started by @qisthidev*