### PR TITLE
⚡ Bolt: Optimize AccessControlInvalidator bulk session deletions

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,6 @@
 ## 2024-05-11 - Optimized Permission Check
 **Learning:** Laravolt's `HasRoleAndPermission` and `Role` models do dynamic query checks or `contains` lookups when `hasPermission` is called. Since permissions are eager-loaded, doing a `contains` operation manually can bypass `app(config(...))` overhead and Model instantiation.
 **Action:** Overrode `_hasPermission` in models to utilize eager-loaded relations properly.
+## 2024-05-22 - Extracted Schema checks from loops
+**Learning:** Calling `Schema::hasTable` or `Schema::hasColumn` inside a loop executes a new database query to the information schema for every iteration, causing a hidden N+1 bottleneck.
+**Action:** Extract Schema checks outside of loops or batch the underlying operations so that the Schema check is only performed once.

--- a/src/Platform/Services/AccessControlInvalidator.php
+++ b/src/Platform/Services/AccessControlInvalidator.php
@@ -22,15 +22,29 @@ class AccessControlInvalidator
 
     public function invalidateUsers(iterable $users): void
     {
+        $userIds = [];
+
         foreach ($users as $user) {
             if ($user instanceof Model) {
-                $this->invalidateUser($user);
+                $userId = $user->getKey();
+                // ⚡ Bolt: Cache doesn't support bulk invalidation, iterate here
+                Cache::forget("users.{$userId}.permissions");
+                $userIds[] = $userId;
             }
+        }
+
+        if (! empty($userIds)) {
+            // ⚡ Bolt: Pass all IDs to bulk delete sessions and avoid N+1 schema checks
+            $this->deleteDatabaseSessions($userIds);
         }
     }
 
     protected function deleteDatabaseSessions(mixed $userId): void
     {
+        if (empty($userId)) {
+            return;
+        }
+
         try {
             $connection = config('session.connection');
             $table = config('session.table', 'sessions');
@@ -40,7 +54,17 @@ class AccessControlInvalidator
                 return;
             }
 
-            DB::connection($connection)->table($table)->where('user_id', $userId)->delete();
+            $query = DB::connection($connection)->table($table);
+
+            if (is_iterable($userId)) {
+                $ids = is_array($userId) ? $userId : iterator_to_array($userId);
+                // ⚡ Bolt: Chunk large arrays to prevent database parameter limit issues
+                foreach (array_chunk($ids, 300) as $chunk) {
+                    (clone $query)->whereIn('user_id', $chunk)->delete();
+                }
+            } else {
+                $query->where('user_id', $userId)->delete();
+            }
         } catch (Throwable) {
             // Session invalidation is best-effort because Laravolt can run with
             // non-database session drivers or applications without session table.


### PR DESCRIPTION
💡 What: Extracted user ID loop processing to perform a bulk delete on `sessions` instead of individual delete statements, and crucially avoided repeating `Schema::hasTable` and `Schema::hasColumn` on every invalidation loop.
🎯 Why: Inside loops, `Schema::hasTable` acts as a hidden N+1 query directly against the information schema. Batching these resolves severe performance degradation when processing many users.
📊 Impact: Reduces database queries from O(N) queries to O(1) chunks for bulk user invalidations.
🔬 Measurement: Verify via Laravel Debugbar or Telescope when triggering `AccessControlInvalidator::invalidateUsers()` with an array of models.

---
*PR created automatically by Jules for task [16023210349300004340](https://jules.google.com/task/16023210349300004340) started by @qisthidev*