### PR TITLE
⚡ Bolt: Optimize Acl permission syncing N+1 queries

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,6 @@
 ## 2024-05-11 - Optimized Permission Check
 **Learning:** Laravolt's `HasRoleAndPermission` and `Role` models do dynamic query checks or `contains` lookups when `hasPermission` is called. Since permissions are eager-loaded, doing a `contains` operation manually can bypass `app(config(...))` overhead and Model instantiation.
 **Action:** Overrode `_hasPermission` in models to utilize eager-loaded relations properly.
+## 2024-05-19 - N+1 Optimizations with Model Events
+**Learning:** When bulk-deleting models to optimize an N+1 query problem, using `$query->whereIn(...)->delete()` bypasses Eloquent model events. In packages like Acl that rely on cache invalidation during `deleting`/`deleted` events, this can lead to stale caches.
+**Action:** When evaluating bulk deletions, check if related cache invalidation or other critical business logic depends on model events. If so, iterate and call `$model->delete()` individually, accepting the query overhead, or implement a manual bulk cache flush. Also, remember that `array_merge` correctly appends elements to numerically indexed arrays, while the `+` operator ignores keys from the right array that exist in the left.

--- a/src/Platform/Services/Acl.php
+++ b/src/Platform/Services/Acl.php
@@ -38,40 +38,54 @@ class Acl
 
     public function syncPermission($refresh = false): Collection
     {
-        return DB::transaction(function () use ($refresh) {
-            if ($refresh) {
-                Schema::disableForeignKeyConstraints();
-                app(config('laravolt.epicentrum.models.permission'))->truncate();
-                Schema::enableForeignKeyConstraints();
-            }
-
-            $items = collect();
-            foreach ($this->permissions() as $name) {
-                $permission = app(config('laravolt.epicentrum.models.permission'))->firstOrNew(['name' => $name]);
-                $status = 'No Change';
-
-                if (! $permission->exists) {
-                    $permission->save();
-                    $status = 'New';
+        return DB::transaction(
+            function () use ($refresh) {
+                if ($refresh) {
+                    Schema::disableForeignKeyConstraints();
+                    app(config('laravolt.epicentrum.models.permission'))->truncate();
+                    Schema::enableForeignKeyConstraints();
                 }
 
-                $items->push(['id' => $permission->getKey(), 'name' => $name, 'status' => $status]);
+                $items = collect();
+                $permissionModel = app(config('laravolt.epicentrum.models.permission'));
+
+                // Optimization: Fetch existing permissions in bulk to prevent N+1 SELECT queries
+                $existingPermissions = $permissionModel->whereIn('name', $this->permissions())
+                    ->get()
+                    ->keyBy('name');
+
+                foreach ($this->permissions() as $name) {
+                    $status = 'No Change';
+                    $permission = $existingPermissions->get($name);
+
+                    if (! $permission) {
+                        // Create missing permission
+                        $permission = $permissionModel->create(['name' => $name]);
+                        // Add to existing permissions to avoid duplicate inserts if array contains duplicates
+                        $existingPermissions->put($name, $permission);
+                        $status = 'New';
+                    }
+
+                    $items->push(['id' => $permission->getKey(), 'name' => $name, 'status' => $status]);
+                }
+
+                // delete unused permissions
+                // Bug fix: array_merge properly appends '*' instead of the '+' operator on indexed arrays
+                $permissions = array_merge($this->permissions(), ['*']);
+                $unusedPermissions = $permissionModel->whereNotIn('name', $permissions)->get();
+
+                if ($unusedPermissions->isNotEmpty()) {
+                    foreach ($unusedPermissions as $permission) {
+                        $items->push(['id' => $permission->getKey(), 'name' => $permission->name, 'status' => 'Deleted']);
+                        // We iterate delete() here instead of bulk delete to ensure Model Events (like caching invalidation) fire
+                        $permission->delete();
+                    }
+                }
+
+                $items = $items->sortBy('name');
+
+                return $items;
             }
-
-            // delete unused permissions
-            $permissions = $this->permissions() + ['*'];
-            $unusedPermissions = app(config('laravolt.epicentrum.models.permission'))
-                ->whereNotIn('name', $permissions)
-                ->get();
-
-            foreach ($unusedPermissions as $permission) {
-                $items->push(['id' => $permission->getKey(), 'name' => $permission->name, 'status' => 'Deleted']);
-                $permission->delete();
-            }
-
-            $items = $items->sortBy('name');
-
-            return $items;
-        });
+        );
     }
 }


### PR DESCRIPTION
💡 **What**: Refactored `Acl::syncPermission` to fetch existing permissions in bulk, eliminating N+1 `SELECT` queries during creation. I also fixed a bug involving `['*']` array merging, and ensured model events still fire properly during permission deletion.

🎯 **Why**: The `syncPermission` method executes a database `SELECT` query via `firstOrNew` for every registered permission. If there are hundreds of permissions, this causes a massive N+1 bottleneck during role/permission syncing. Additionally, the `+` array operator was ignoring the `*` permission when deleting unused permissions.

📊 **Impact**: Reduces `SELECT` queries from $O(N)$ (where N is the number of registered permissions) to $O(1)$. This makes the permission synchronization process significantly faster, particularly on system boot or migration.

🔬 **Measurement**: Verified using Pest tests in an in-memory SQLite database (`AclServiceTest.php`). Queries can be measured via Laravel Telescope or DB Query Logging before and after running the sync command.

---
*PR created automatically by Jules for task [12316344984660599672](https://jules.google.com/task/12316344984660599672) started by @qisthidev*