### PR TITLE
⚡ Bolt: Optimize bulk role and permission string resolution

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,6 @@
 ## 2024-05-11 - Optimized Permission Check
 **Learning:** Laravolt's `HasRoleAndPermission` and `Role` models do dynamic query checks or `contains` lookups when `hasPermission` is called. Since permissions are eager-loaded, doing a `contains` operation manually can bypass `app(config(...))` overhead and Model instantiation.
 **Action:** Overrode `_hasPermission` in models to utilize eager-loaded relations properly.
+## 2024-05-24 - Bulk String Model Lookups Should Match DB Collation Sensitivity
+**Learning:** When optimizing N+1 string name lookups (e.g. roles, permissions) by loading them into an in-memory Laravel Collection via `keyBy('name')`, PHP treats string keys as case-sensitive. However, the database might be case-insensitive (like MySQL default). This can cause an existing item to be missed and re-created (throwing constraint errors) if the case differs.
+**Action:** When keying a Collection by a string identifier for existence checks, use `->keyBy(fn($item) => strtolower($item->name))` and check with `has(strtolower($name))` to simulate case-insensitive collation in PHP memory.

--- a/src/Platform/Concerns/HasRoleAndPermission.php
+++ b/src/Platform/Concerns/HasRoleAndPermission.php
@@ -37,10 +37,12 @@ trait HasRoleAndPermission
                 ->where('users.id', $this->getKey())
                 ->get()
                 ->unique('id')
-                ->map(fn ($permission) => [
+                ->map(
+                    fn ($permission) => [
                     'id' => $permission->getKey(),
                     'name' => (string) ($permission->name ?? ''),
-                ])
+                    ]
+                )
                 ->values()
                 ->all();
         };
@@ -187,40 +189,78 @@ trait HasRoleAndPermission
 
     protected function resolveRoleIds($roles, bool $createMissing = false): array
     {
-        return collect(is_array($roles) ? $roles : [$roles])
-            ->map(function ($role) use ($createMissing) {
-                if (is_numeric($role)) {
-                    return (int) $role;
-                }
+        $rolesArray = is_array($roles) ? $roles : [$roles];
 
-                if (is_string($role) && Str::isUuid($role)) {
+        // ⚡ Bolt: Bulk query string roles to avoid N+1
+        $stringRoleNames = [];
+        foreach ($rolesArray as $role) {
+            if (is_string($role) && !Str::isUuid($role) && !str($role)->isUlid()) {
+                $stringRoleNames[] = $role;
+            }
+        }
+
+        $existingRoles = collect();
+        if (!empty($stringRoleNames)) {
+            $existingRoles = app(config('laravolt.epicentrum.models.role'))
+                ->whereIn('name', $stringRoleNames)
+                ->get()
+                ->keyBy(
+                    function ($item) {
+                        return strtolower($item->name);
+                    }
+                );
+        }
+
+        return collect($rolesArray)
+            ->map(
+                function ($role) use ($createMissing, $existingRoles) {
+                    if (is_numeric($role)) {
+                        return (int) $role;
+                    }
+
+                    if (is_string($role) && Str::isUuid($role)) {
+                        return $role;
+                    }
+
+                    if (is_string($role)) {
+                        if (str($role)->isUlid()) {
+                            return $role;
+                        }
+
+                        $roleLower = strtolower($role);
+                        if ($existingRoles->has($roleLower)) {
+                            return $existingRoles->get($roleLower)->getKey();
+                        }
+
+                        if ($createMissing) {
+                            $newRole = app(config('laravolt.epicentrum.models.role'))->firstOrCreate(['name' => $role]);
+                            $existingRoles->put($roleLower, $newRole);
+                            return $newRole->getKey();
+                        }
+
+                        return null;
+                    }
+
+                    if ($role instanceof Model) {
+                        return $role->getKey();
+                    }
+
                     return $role;
                 }
+            )
+            ->filter(
+                function ($id) {
+                    if (is_int($id)) {
+                        return $id > 0;
+                    }
 
-                if (is_string($role)) {
-                    $query = app(config('laravolt.epicentrum.models.role'))->where('name', $role);
-                    $role = $createMissing ? $query->firstOrCreate(['name' => $role]) : $query->first();
+                    if (is_string($id)) {
+                        return trim($id) !== '';
+                    }
 
-                    return $role?->getKey();
+                    return false;
                 }
-
-                if ($role instanceof Model) {
-                    return $role->getKey();
-                }
-
-                return $role;
-            })
-            ->filter(function ($id) {
-                if (is_int($id)) {
-                    return $id > 0;
-                }
-
-                if (is_string($id)) {
-                    return trim($id) !== '';
-                }
-
-                return false;
-            })
+            )
             ->all();
     }
 

--- a/src/Platform/Models/Role.php
+++ b/src/Platform/Models/Role.php
@@ -57,39 +57,73 @@ class Role extends Model
 
     public function hasPermission($permission)
     {
-        return once(function () use ($permission) {
-            return $this->_hasPermission($permission);
-        });
+        return once(
+            function () use ($permission) {
+                return $this->_hasPermission($permission);
+            }
+        );
     }
 
     public function syncPermission(array $permissions)
     {
-        $ids = collect($permissions)->transform(function ($permission) {
-            if (is_string($permission) && str($permission)->isUlid()) {
-                return $permission;
+        // ⚡ Bolt: Bulk query string permissions to avoid N+1
+        $stringPermissionNames = [];
+        foreach ($permissions as $permission) {
+            if (is_string($permission) && !Str::isUuid($permission) && !str($permission)->isUlid() && !is_numeric($permission)) {
+                $stringPermissionNames[] = $permission;
             }
-            if (is_numeric($permission)) {
-                return (int) $permission;
-            }
-            if (is_string($permission)) {
-                $permissionObject = app(config('laravolt.epicentrum.models.permission'))->firstOrCreate(['name' => $permission]);
+        }
 
-                return $permissionObject->getKey();
-            }
-            if ($permission instanceof Model) {
-                return $permission->getKey();
-            }
-        })->filter(function ($id) {
-            if (is_int($id)) {
-                return $id > 0;
-            }
+        $existingPermissions = collect();
+        if (!empty($stringPermissionNames)) {
+            $existingPermissions = app(config('laravolt.epicentrum.models.permission'))
+                ->whereIn('name', $stringPermissionNames)
+                ->get()
+                ->keyBy(
+                    function ($item) {
+                        return strtolower($item->name);
+                    }
+                );
+        }
 
-            if (is_string($id)) {
-                return trim($id) !== '';
-            }
+        $ids = collect($permissions)->transform(
+            function ($permission) use ($existingPermissions) {
+                if (is_string($permission) && str($permission)->isUlid()) {
+                    return $permission;
+                }
+                if (is_string($permission) && Str::isUuid($permission)) {
+                    return $permission;
+                }
+                if (is_numeric($permission)) {
+                    return (int) $permission;
+                }
+                if (is_string($permission)) {
+                    $permissionLower = strtolower($permission);
+                    if ($existingPermissions->has($permissionLower)) {
+                        return $existingPermissions->get($permissionLower)->getKey();
+                    }
 
-            return false;
-        });
+                    $newPermission = app(config('laravolt.epicentrum.models.permission'))->firstOrCreate(['name' => $permission]);
+                    $existingPermissions->put($permissionLower, $newPermission);
+                    return $newPermission->getKey();
+                }
+                if ($permission instanceof Model) {
+                    return $permission->getKey();
+                }
+            }
+        )->filter(
+            function ($id) {
+                if (is_int($id)) {
+                    return $id > 0;
+                }
+
+                if (is_string($id)) {
+                    return trim($id) !== '';
+                }
+
+                return false;
+            }
+        );
 
         $changes = $this->permissions()->sync($ids->toArray());
 


### PR DESCRIPTION
💡 What: Optimized `resolveRoleIds` in `HasRoleAndPermission` trait and `syncPermission` in `Role` model to execute a single `whereIn` query for string-based role/permission names instead of executing individual `firstOrCreate()` or `where()->first()` queries in a loop.
🎯 Why: Passing an array of string roles or permissions resulted in an N+1 query bottleneck (executing a SELECT/INSERT for every string element).
📊 Impact: Reduces database queries for string-based role/permission syncing from O(N) to O(1), significantly improving performance during bulk assignment operations.
🔬 Measurement: Verify by executing `$user->syncRoles(['role1', 'role2', 'role3'])` and observing the query log. The multiple `SELECT * FROM roles WHERE name = ?` queries will be replaced by a single `SELECT * FROM roles WHERE name IN (?, ?, ?)`.

---
*PR created automatically by Jules for task [300902694090376402](https://jules.google.com/task/300902694090376402) started by @qisthidev*