### PR TITLE
⚡ Bolt: Optimize AccessControlInvalidator bulk session deletion

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,6 @@
 ## 2024-05-11 - Optimized Permission Check
 **Learning:** Laravolt's `HasRoleAndPermission` and `Role` models do dynamic query checks or `contains` lookups when `hasPermission` is called. Since permissions are eager-loaded, doing a `contains` operation manually can bypass `app(config(...))` overhead and Model instantiation.
 **Action:** Overrode `_hasPermission` in models to utilize eager-loaded relations properly.
+## 2024-05-11 - Bulk Delete Database Sessions
+**Learning:** Checking the database schema (`Schema::hasTable`, `Schema::hasColumn`) inside a loop incurs significant N+1 hidden queries to the information_schema, degrading performance severely during batch updates. Extracting these checks out of loops is critical.
+**Action:** When performing bulk cache/db cleanups (like session expirations), collect IDs in a loop and execute a single `whereIn()->delete()` with the schema check executed once beforehand.

--- a/src/Platform/Services/AccessControlInvalidator.php
+++ b/src/Platform/Services/AccessControlInvalidator.php
@@ -17,30 +17,44 @@ class AccessControlInvalidator
         $userId = $user->getKey();
 
         Cache::forget("users.{$userId}.permissions");
-        $this->deleteDatabaseSessions($userId);
+        $this->deleteDatabaseSessions([$userId]);
     }
 
     public function invalidateUsers(iterable $users): void
     {
+        $userIds = [];
+
         foreach ($users as $user) {
             if ($user instanceof Model) {
-                $this->invalidateUser($user);
+                $userId = $user->getKey();
+                // We still need to invalidate cache individually
+                Cache::forget("users.{$userId}.permissions");
+                $userIds[] = $userId;
             }
+        }
+
+        if (!empty($userIds)) {
+            $this->deleteDatabaseSessions($userIds);
         }
     }
 
-    protected function deleteDatabaseSessions(mixed $userId): void
+    /**
+     * @param array<mixed> $userIds
+     */
+    protected function deleteDatabaseSessions(array $userIds): void
     {
         try {
             $connection = config('session.connection');
             $table = config('session.table', 'sessions');
             $schema = Schema::connection($connection);
 
+            // Avoid checking schema in a loop by passing an array of user IDs
+            // and executing a single check and bulk delete.
             if (! $schema->hasTable($table) || ! $schema->hasColumn($table, 'user_id')) {
                 return;
             }
 
-            DB::connection($connection)->table($table)->where('user_id', $userId)->delete();
+            DB::connection($connection)->table($table)->whereIn('user_id', $userIds)->delete();
         } catch (Throwable) {
             // Session invalidation is best-effort because Laravolt can run with
             // non-database session drivers or applications without session table.


### PR DESCRIPTION
💡 What: Refactored `AccessControlInvalidator::invalidateUsers` and `deleteDatabaseSessions` to collect user IDs in a loop and perform a single `whereIn()->delete()` query.
🎯 Why: Previously, invalidating sessions for multiple users inside a loop caused an N+1 query issue for `delete()` on the database session driver. More severely, it forced `Schema::hasTable` and `Schema::hasColumn` to execute on every loop iteration, which trigger costly queries to the `information_schema`.
📊 Impact: Reduces database queries from O(N) to O(1) for session deletions. Substantially lowers latency and database load during bulk ACL invalidation.
🔬 Measurement: Verify by executing batch role/permission updates or logging out multiple users. The Laravel Telescope or debugbar should now show a single schema check and a single `DELETE` query rather than proportional to the number of users.

---
*PR created automatically by Jules for task [4494272882304704613](https://jules.google.com/task/4494272882304704613) started by @qisthidev*