### PR TITLE
⚡ Bolt: Optimize user session invalidation with batched queries

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,6 @@
 ## 2024-05-11 - Optimized Permission Check
 **Learning:** Laravolt's `HasRoleAndPermission` and `Role` models do dynamic query checks or `contains` lookups when `hasPermission` is called. Since permissions are eager-loaded, doing a `contains` operation manually can bypass `app(config(...))` overhead and Model instantiation.
 **Action:** Overrode `_hasPermission` in models to utilize eager-loaded relations properly.
+## 2026-05-28 - Optimized AccessControlInvalidator loop
+**Learning:** When invalidating user sessions in Laravolt, `AccessControlInvalidator` previously checked the schema for the session table (O(N)) and executed a `delete()` query inside a foreach loop over user IDs (O(N)). While small loops are typically fast, this architecture triggers numerous schema queries that drastically drop performance under load.
+**Action:** Batch schema checking to happen only once, and perform bulk deletion using `whereIn()` to eliminate N+1 query bottlenecks in invalidation loops.

--- a/src/Platform/Services/AccessControlInvalidator.php
+++ b/src/Platform/Services/AccessControlInvalidator.php
@@ -22,14 +22,21 @@ class AccessControlInvalidator
 
     public function invalidateUsers(iterable $users): void
     {
+        $userIds = [];
         foreach ($users as $user) {
             if ($user instanceof Model) {
-                $this->invalidateUser($user);
+                $userId = $user->getKey();
+                Cache::forget("users.{$userId}.permissions");
+                $userIds[] = $userId;
             }
+        }
+
+        if (!empty($userIds)) {
+            $this->deleteDatabaseSessions($userIds);
         }
     }
 
-    protected function deleteDatabaseSessions(mixed $userId): void
+    protected function deleteDatabaseSessions(mixed $userIds): void
     {
         try {
             $connection = config('session.connection');
@@ -40,7 +47,9 @@ class AccessControlInvalidator
                 return;
             }
 
-            DB::connection($connection)->table($table)->where('user_id', $userId)->delete();
+            $userIdsArray = is_array($userIds) ? $userIds : [$userIds];
+
+            DB::connection($connection)->table($table)->whereIn('user_id', $userIdsArray)->delete();
         } catch (Throwable) {
             // Session invalidation is best-effort because Laravolt can run with
             // non-database session drivers or applications without session table.


### PR DESCRIPTION
💡 **What**:
Modified `AccessControlInvalidator::invalidateUsers()` to collect user IDs in an array and pass them to a modified `deleteDatabaseSessions()` which now accepts mixed types and executes a single `whereIn('user_id', $userIdsArray)->delete()` query instead of multiple `delete()` calls inside a loop.

🎯 **Why**:
The original implementation had an N+1 query vulnerability when iterating over a collection of users to invalidate them. For each user in the `iterable $users`, it called `deleteDatabaseSessions()`, which triggered a `Schema::hasTable()` check, a `Schema::hasColumn()` check, and a standard `delete()` query. This severely hampered performance when attempting to invalidate many users simultaneously.

📊 **Impact**:
Reduces database round-trips for user invalidation from *O(N)* to *O(1)*. By moving the Schema checks and the deletion query out of the loop and batching them, we save 3 queries per user invalidated (two schema queries, one deletion query).

🔬 **Measurement**:
Measure performance by using a large collection of users (e.g., ~1000 items) and passing it to `app(AccessControlInvalidator::class)->invalidateUsers($users)`. The execution time and total number of queries (logged via DB query log or Telescope) will be significantly lower.

---
*PR created automatically by Jules for task [17877382264169712799](https://jules.google.com/task/17877382264169712799) started by @qisthidev*