### PR TITLE
⚡ Bolt: Optimize role and permission syncing by fixing N+1 queries

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,7 @@
 ## 2024-05-11 - Optimized Permission Check
 **Learning:** Laravolt's `HasRoleAndPermission` and `Role` models do dynamic query checks or `contains` lookups when `hasPermission` is called. Since permissions are eager-loaded, doing a `contains` operation manually can bypass `app(config(...))` overhead and Model instantiation.
 **Action:** Overrode `_hasPermission` in models to utilize eager-loaded relations properly.
+
+## 2024-05-11 - Bulk Relationship Querying for ACL
+**Learning:** In `HasRoleAndPermission` and `Role` models, syncing relationships with arrays of string identifiers caused an N+1 query problem by invoking `firstOrCreate` on every iteration.
+**Action:** Extract string identifiers into a separate array, query them in bulk via `whereIn`, and index them using a case-insensitive Collection (`keyBy(fn ($item) => strtolower($item->name))`). Look up from the collection inside the loop.

--- a/src/Platform/Concerns/HasRoleAndPermission.php
+++ b/src/Platform/Concerns/HasRoleAndPermission.php
@@ -37,10 +37,12 @@ trait HasRoleAndPermission
                 ->where('users.id', $this->getKey())
                 ->get()
                 ->unique('id')
-                ->map(fn ($permission) => [
+                ->map(
+                    fn ($permission) => [
                     'id' => $permission->getKey(),
                     'name' => (string) ($permission->name ?? ''),
-                ])
+                    ]
+                )
                 ->values()
                 ->all();
         };
@@ -187,40 +189,68 @@ trait HasRoleAndPermission
 
     protected function resolveRoleIds($roles, bool $createMissing = false): array
     {
-        return collect(is_array($roles) ? $roles : [$roles])
-            ->map(function ($role) use ($createMissing) {
-                if (is_numeric($role)) {
-                    return (int) $role;
-                }
+        $rolesArray = is_array($roles) ? $roles : [$roles];
 
-                if (is_string($role) && Str::isUuid($role)) {
+        $stringRoles = array_filter(
+            $rolesArray, function ($role) {
+                return is_string($role) && !is_numeric($role) && !Str::isUuid($role) && !str($role)->isUlid();
+            }
+        );
+
+        // ⚡ Bolt: Fetch existing roles in bulk to avoid N+1 queries when calling `firstOrCreate` in the loop
+        $existingRoles = collect();
+        if (!empty($stringRoles)) {
+            $existingRoles = app(config('laravolt.epicentrum.models.role'))
+                ->whereIn('name', $stringRoles)
+                ->get()
+                ->keyBy(fn ($item) => strtolower($item->name));
+        }
+
+        return collect($rolesArray)
+            ->map(
+                function ($role) use ($createMissing, $existingRoles) {
+                    if (is_numeric($role)) {
+                        return (int) $role;
+                    }
+
+                    if (is_string($role) && (Str::isUuid($role) || str($role)->isUlid())) {
+                        return $role;
+                    }
+
+                    if (is_string($role)) {
+                        $lowerRole = strtolower($role);
+                        if ($existingRoles->has($lowerRole)) {
+                            return $existingRoles->get($lowerRole)->getKey();
+                        }
+
+                        if ($createMissing) {
+                            $newRole = app(config('laravolt.epicentrum.models.role'))->firstOrCreate(['name' => $role]);
+                            return $newRole->getKey();
+                        }
+
+                        return null;
+                    }
+
+                    if ($role instanceof Model) {
+                        return $role->getKey();
+                    }
+
                     return $role;
                 }
+            )
+            ->filter(
+                function ($id) {
+                    if (is_int($id)) {
+                        return $id > 0;
+                    }
 
-                if (is_string($role)) {
-                    $query = app(config('laravolt.epicentrum.models.role'))->where('name', $role);
-                    $role = $createMissing ? $query->firstOrCreate(['name' => $role]) : $query->first();
+                    if (is_string($id)) {
+                        return trim($id) !== '';
+                    }
 
-                    return $role?->getKey();
+                    return false;
                 }
-
-                if ($role instanceof Model) {
-                    return $role->getKey();
-                }
-
-                return $role;
-            })
-            ->filter(function ($id) {
-                if (is_int($id)) {
-                    return $id > 0;
-                }
-
-                if (is_string($id)) {
-                    return trim($id) !== '';
-                }
-
-                return false;
-            })
+            )
             ->all();
     }
 

--- a/src/Platform/Models/Role.php
+++ b/src/Platform/Models/Role.php
@@ -57,39 +57,65 @@ class Role extends Model
 
     public function hasPermission($permission)
     {
-        return once(function () use ($permission) {
-            return $this->_hasPermission($permission);
-        });
+        return once(
+            function () use ($permission) {
+                return $this->_hasPermission($permission);
+            }
+        );
     }
 
     public function syncPermission(array $permissions)
     {
-        $ids = collect($permissions)->transform(function ($permission) {
-            if (is_string($permission) && str($permission)->isUlid()) {
-                return $permission;
+        $stringPermissions = array_filter(
+            $permissions, function ($permission) {
+                return is_string($permission) && !is_numeric($permission) && !str($permission)->isUlid() && !\Illuminate\Support\Str::isUuid($permission);
             }
-            if (is_numeric($permission)) {
-                return (int) $permission;
-            }
-            if (is_string($permission)) {
-                $permissionObject = app(config('laravolt.epicentrum.models.permission'))->firstOrCreate(['name' => $permission]);
+        );
 
-                return $permissionObject->getKey();
-            }
-            if ($permission instanceof Model) {
-                return $permission->getKey();
-            }
-        })->filter(function ($id) {
-            if (is_int($id)) {
-                return $id > 0;
-            }
+        // ⚡ Bolt: Fetch existing permissions in bulk to avoid N+1 queries when calling `firstOrCreate` in the loop
+        $existingPermissions = collect();
+        if (!empty($stringPermissions)) {
+            $existingPermissions = app(config('laravolt.epicentrum.models.permission'))
+                ->whereIn('name', $stringPermissions)
+                ->get()
+                ->keyBy(fn ($item) => strtolower($item->name));
+        }
 
-            if (is_string($id)) {
-                return trim($id) !== '';
-            }
+        $ids = collect($permissions)->transform(
+            function ($permission) use ($existingPermissions) {
+                if (is_string($permission) && (str($permission)->isUlid() || \Illuminate\Support\Str::isUuid($permission))) {
+                    return $permission;
+                }
+                if (is_numeric($permission)) {
+                    return (int) $permission;
+                }
+                if (is_string($permission)) {
+                    $lowerPermission = strtolower($permission);
+                    if ($existingPermissions->has($lowerPermission)) {
+                        return $existingPermissions->get($lowerPermission)->getKey();
+                    }
 
-            return false;
-        });
+                    $permissionObject = app(config('laravolt.epicentrum.models.permission'))->firstOrCreate(['name' => $permission]);
+
+                    return $permissionObject->getKey();
+                }
+                if ($permission instanceof Model) {
+                    return $permission->getKey();
+                }
+            }
+        )->filter(
+            function ($id) {
+                if (is_int($id)) {
+                    return $id > 0;
+                }
+
+                if (is_string($id)) {
+                    return trim($id) !== '';
+                }
+
+                return false;
+            }
+        );
 
         $changes = $this->permissions()->sync($ids->toArray());
 


### PR DESCRIPTION
💡 **What:** Optimized `resolveRoleIds` (in `HasRoleAndPermission`) and `syncPermission` (in `Role`) to bulk query existing string identifiers using `whereIn` before iterating.
🎯 **Why:** The previous implementation used `firstOrCreate` inside a `.map()`/`.transform()` loop. For large arrays of roles or permissions, this resulted in N+1 database queries.
📊 **Impact:** Reduces database queries for syncing roles/permissions from O(N) to O(1) for existing entities, significantly speeding up ACL synchronization and permission assignment flows.
🔬 **Measurement:** Verify by running DB query logging before and after syncing an array of 50 existing roles to a user or permissions to a role. The queries should drop from ~50 to 1 `SELECT ... WHERE name IN (...)`.

---
*PR created automatically by Jules for task [4012986352382719390](https://jules.google.com/task/4012986352382719390) started by @qisthidev*