### PR TITLE
⚡ Bolt: Optimize bulk relationship mapping and prevent N+1 queries

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,6 @@
 ## 2024-05-11 - Optimized Permission Check
 **Learning:** Laravolt's `HasRoleAndPermission` and `Role` models do dynamic query checks or `contains` lookups when `hasPermission` is called. Since permissions are eager-loaded, doing a `contains` operation manually can bypass `app(config(...))` overhead and Model instantiation.
 **Action:** Overrode `_hasPermission` in models to utilize eager-loaded relations properly.
+## 2024-05-11 - Bulk query existing relationships with firstOrCreate batching
+**Learning:** In loops handling string names for models (like syncing permissions or roles), using `firstOrCreate` directly causes an N+1 issue. We must combine `whereIn` batching first and only loop missing ones through `firstOrCreate`, while handling string identifiers mapping efficiently.
+**Action:** Extract string names, perform a single `whereIn('name', ...)` lookup, populate a map of name to primary keys, call `firstOrCreate` on missing elements dynamically, and pass the populated lookup to the main iterator.

--- a/src/Platform/Concerns/HasRoleAndPermission.php
+++ b/src/Platform/Concerns/HasRoleAndPermission.php
@@ -187,8 +187,30 @@ trait HasRoleAndPermission
 
     protected function resolveRoleIds($roles, bool $createMissing = false): array
     {
-        return collect(is_array($roles) ? $roles : [$roles])
-            ->map(function ($role) use ($createMissing) {
+        $rolesArray = is_array($roles) ? $roles : [$roles];
+
+        // ⚡ Bolt: Prevent N+1 by bulk querying and creating string roles
+        $stringNames = array_filter($rolesArray, function ($r) {
+            return is_string($r) && !Str::isUuid($r) && !is_numeric($r);
+        });
+
+        $nameLookup = [];
+        if (!empty($stringNames)) {
+            $roleModel = app(config('laravolt.epicentrum.models.role'));
+            $existing = $roleModel->whereIn('name', $stringNames)->get()->keyBy('name');
+
+            foreach ($stringNames as $name) {
+                if ($existing->has($name)) {
+                    $nameLookup[$name] = $existing->get($name)->getKey();
+                } elseif ($createMissing) {
+                    $newRole = $roleModel->firstOrCreate(['name' => $name]);
+                    $nameLookup[$name] = $newRole->getKey();
+                }
+            }
+        }
+
+        return collect($rolesArray)
+            ->map(function ($role) use ($nameLookup) {
                 if (is_numeric($role)) {
                     return (int) $role;
                 }
@@ -198,10 +220,7 @@ trait HasRoleAndPermission
                 }
 
                 if (is_string($role)) {
-                    $query = app(config('laravolt.epicentrum.models.role'))->where('name', $role);
-                    $role = $createMissing ? $query->firstOrCreate(['name' => $role]) : $query->first();
-
-                    return $role?->getKey();
+                    return $nameLookup[$role] ?? null;
                 }
 
                 if ($role instanceof Model) {

--- a/src/Platform/Models/Role.php
+++ b/src/Platform/Models/Role.php
@@ -64,7 +64,27 @@ class Role extends Model
 
     public function syncPermission(array $permissions)
     {
-        $ids = collect($permissions)->transform(function ($permission) {
+        // ⚡ Bolt: Prevent N+1 by bulk querying and creating string permissions
+        $stringNames = array_filter($permissions, function ($p) {
+            return is_string($p) && !str($p)->isUlid() && !is_numeric($p);
+        });
+
+        $nameLookup = [];
+        if (!empty($stringNames)) {
+            $permissionModel = app(config('laravolt.epicentrum.models.permission'));
+            $existing = $permissionModel->whereIn('name', $stringNames)->get()->keyBy('name');
+
+            foreach ($stringNames as $name) {
+                if ($existing->has($name)) {
+                    $nameLookup[$name] = $existing->get($name)->getKey();
+                } else {
+                    $newPerm = $permissionModel->firstOrCreate(['name' => $name]);
+                    $nameLookup[$name] = $newPerm->getKey();
+                }
+            }
+        }
+
+        $ids = collect($permissions)->transform(function ($permission) use ($nameLookup) {
             if (is_string($permission) && str($permission)->isUlid()) {
                 return $permission;
             }
@@ -72,9 +92,7 @@ class Role extends Model
                 return (int) $permission;
             }
             if (is_string($permission)) {
-                $permissionObject = app(config('laravolt.epicentrum.models.permission'))->firstOrCreate(['name' => $permission]);
-
-                return $permissionObject->getKey();
+                return $nameLookup[$permission] ?? null;
             }
             if ($permission instanceof Model) {
                 return $permission->getKey();


### PR DESCRIPTION
💡 **What**: Replaced sequential, per-item `firstOrCreate` DB queries inside relationship mapping loops with a single, batched `whereIn` lookup and mapped associative array logic.
🎯 **Why**: When passing an array of string permissions or roles to `syncPermission` or `assignRole`, the underlying system was executing a `firstOrCreate` DB query for *every* individual string in the array (N+1 queries). This caused significant latency bottlenecks when hydrating relationships or assigning bulk attributes.
📊 **Impact**: Reduces N+1 database queries from O(N) queries to O(1) bulk fetch + O(X) creates (where X is strictly the number of missing items). Significantly lowers latency and database round-trips when assigning dozens of permissions.
🔬 **Measurement**: Verify by inspecting Laravel Debugbar or Telescope during role assignment containing a long list of string permissions. Query count should shrink drastically.

---
*PR created automatically by Jules for task [10227367350464306162](https://jules.google.com/task/10227367350464306162) started by @qisthidev*