### PR TITLE
⚡ Bolt: optimize Acl syncPermission N+1 and fix array union bug

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,6 @@
 ## 2024-05-11 - Optimized Permission Check
 **Learning:** Laravolt's `HasRoleAndPermission` and `Role` models do dynamic query checks or `contains` lookups when `hasPermission` is called. Since permissions are eager-loaded, doing a `contains` operation manually can bypass `app(config(...))` overhead and Model instantiation.
 **Action:** Overrode `_hasPermission` in models to utilize eager-loaded relations properly.
+## 2025-02-12 - Prevent N+1 select queries and array union data loss in ACL syncPermission
+**Learning:** In PHP, using the array union `+` operator on numerically indexed arrays (e.g., `$arr1 + $arr2`) ignores values from the right-hand array if the index already exists in the left. This caused the `*` permission to be silently dropped during permission synchronization when `+ ['*']` was used. Additionally, looping over models to run `firstOrNew` introduces N+1 select queries which can be easily batched.
+**Action:** Always use `array_merge()` or append via `$arr[] =` for mathematically combining standard arrays in PHP. For checking existing database items against an array of identifiers, use a single `whereIn()` query and map the collection by a case-insensitive key instead of querying in a loop.

--- a/src/Platform/Services/Acl.php
+++ b/src/Platform/Services/Acl.php
@@ -38,40 +38,54 @@ class Acl
 
     public function syncPermission($refresh = false): Collection
     {
-        return DB::transaction(function () use ($refresh) {
-            if ($refresh) {
-                Schema::disableForeignKeyConstraints();
-                app(config('laravolt.epicentrum.models.permission'))->truncate();
-                Schema::enableForeignKeyConstraints();
-            }
-
-            $items = collect();
-            foreach ($this->permissions() as $name) {
-                $permission = app(config('laravolt.epicentrum.models.permission'))->firstOrNew(['name' => $name]);
-                $status = 'No Change';
-
-                if (! $permission->exists) {
-                    $permission->save();
-                    $status = 'New';
+        return DB::transaction(
+            function () use ($refresh) {
+                if ($refresh) {
+                    Schema::disableForeignKeyConstraints();
+                    app(config('laravolt.epicentrum.models.permission'))->truncate();
+                    Schema::enableForeignKeyConstraints();
                 }
 
-                $items->push(['id' => $permission->getKey(), 'name' => $name, 'status' => $status]);
+                $items = collect();
+                $permissionsList = $this->permissions();
+
+                // ⚡ Bolt Optimization: Pre-fetch all requested permissions in a single query to avoid N+1 issues
+                // Key the fetched collection by lowercase name to ensure case-insensitive matching in memory
+                $existingPermissions = app(config('laravolt.epicentrum.models.permission'))
+                    ->whereIn('name', $permissionsList)
+                    ->get()
+                    ->keyBy(fn ($item) => strtolower($item->name));
+
+                foreach ($permissionsList as $name) {
+                    $lowerName = strtolower($name);
+                    $status = 'No Change';
+
+                    if ($existingPermissions->has($lowerName)) {
+                        $permission = $existingPermissions->get($lowerName);
+                    } else {
+                        $permission = app(config('laravolt.epicentrum.models.permission'))->create(['name' => $name]);
+                        $status = 'New';
+                    }
+
+                    $items->push(['id' => $permission->getKey(), 'name' => $name, 'status' => $status]);
+                }
+
+                // delete unused permissions
+                // Fix: avoid using array union operator `+` on numerically indexed arrays as it drops values
+                $permissions = array_merge($permissionsList, ['*']);
+                $unusedPermissions = app(config('laravolt.epicentrum.models.permission'))
+                    ->whereNotIn('name', $permissions)
+                    ->get();
+
+                foreach ($unusedPermissions as $permission) {
+                    $items->push(['id' => $permission->getKey(), 'name' => $permission->name, 'status' => 'Deleted']);
+                    $permission->delete();
+                }
+
+                $items = $items->sortBy('name');
+
+                return $items;
             }
-
-            // delete unused permissions
-            $permissions = $this->permissions() + ['*'];
-            $unusedPermissions = app(config('laravolt.epicentrum.models.permission'))
-                ->whereNotIn('name', $permissions)
-                ->get();
-
-            foreach ($unusedPermissions as $permission) {
-                $items->push(['id' => $permission->getKey(), 'name' => $permission->name, 'status' => 'Deleted']);
-                $permission->delete();
-            }
-
-            $items = $items->sortBy('name');
-
-            return $items;
-        });
+        );
     }
 }


### PR DESCRIPTION
💡 What:
Pre-fetch all existing permissions in a single `whereIn` query rather than executing `firstOrNew` inside a loop. Additionally, replace a buggy array union `+` with `array_merge` to prevent dropping the wildcard `*` permission.

🎯 Why:
To prevent N+1 select queries when synchronizing a large list of permissions. The array union bug was causing `*` to drop out of the list if the left hand array wasn't empty, as both arrays had the numeric index `0`.

📊 Impact:
Reduces database read queries for permission synchronization from O(N) to O(1). Ensures all permissions are processed correctly.

🔬 Measurement:
Running tests in `tests/Feature/Acl/AclServiceTest.php` passes, and the SQL logs would show exactly 1 SELECT query during permission creation instead of N.

---
*PR created automatically by Jules for task [878491855621528280](https://jules.google.com/task/878491855621528280) started by @qisthidev*