### PR TITLE
⚡ Bolt: Optimize bulk database session deletion

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,6 @@
 ## 2024-05-11 - Optimized Permission Check
 **Learning:** Laravolt's `HasRoleAndPermission` and `Role` models do dynamic query checks or `contains` lookups when `hasPermission` is called. Since permissions are eager-loaded, doing a `contains` operation manually can bypass `app(config(...))` overhead and Model instantiation.
 **Action:** Overrode `_hasPermission` in models to utilize eager-loaded relations properly.
+## 2024-05-11 - Bulk Database Session Deletion Optimization
+**Learning:** In `Laravolt\Platform\Services\AccessControlInvalidator`, deleting sessions inside a loop when invalidating multiple users creates a hidden N+1 query bottleneck since each user invalidation triggered a separate `DELETE` query on the session table. Also, since Laravel Cache does not natively support bulk `forget()`, iterating through `Cache::forget` remains necessary while we bulk-optimize the database operation using `whereIn()->delete()`.
+**Action:** Overrode `invalidateUsers` to accumulate user IDs in an array, loop over `Cache::forget` individually, and then perform a single `whereIn('user_id', $userIds)->delete()` to optimize database round-trips from O(N) to O(1).

--- a/src/Platform/Services/AccessControlInvalidator.php
+++ b/src/Platform/Services/AccessControlInvalidator.php
@@ -17,20 +17,32 @@ class AccessControlInvalidator
         $userId = $user->getKey();
 
         Cache::forget("users.{$userId}.permissions");
-        $this->deleteDatabaseSessions($userId);
+        $this->deleteDatabaseSessions([$userId]);
     }
 
     public function invalidateUsers(iterable $users): void
     {
+        $userIds = [];
+
         foreach ($users as $user) {
             if ($user instanceof Model) {
-                $this->invalidateUser($user);
+                $userId = $user->getKey();
+                Cache::forget("users.{$userId}.permissions");
+                $userIds[] = $userId;
             }
+        }
+
+        if (!empty($userIds)) {
+            $this->deleteDatabaseSessions($userIds);
         }
     }
 
-    protected function deleteDatabaseSessions(mixed $userId): void
+    protected function deleteDatabaseSessions(array $userIds): void
     {
+        if (empty($userIds)) {
+            return;
+        }
+
         try {
             $connection = config('session.connection');
             $table = config('session.table', 'sessions');
@@ -40,7 +52,7 @@ class AccessControlInvalidator
                 return;
             }
 
-            DB::connection($connection)->table($table)->where('user_id', $userId)->delete();
+            DB::connection($connection)->table($table)->whereIn('user_id', $userIds)->delete();
         } catch (Throwable) {
             // Session invalidation is best-effort because Laravolt can run with
             // non-database session drivers or applications without session table.


### PR DESCRIPTION
💡 **What**: Refactored `AccessControlInvalidator::invalidateUsers()` to collect user IDs and execute a single `whereIn()->delete()` query instead of running individual `DELETE` queries inside a `foreach` loop.
🎯 **Why**: When a role is updated, `invalidateAssignedUsersAccessControl()` is called. If the role has thousands of users, the previous code fired thousands of identical `DELETE` queries to clear database sessions, causing a severe N+1 query bottleneck and database lock contention.
📊 **Impact**: Reduces database round-trips for session deletion from O(N) to O(1) when bulk invalidating users.
🔬 **Measurement**: Verify by mocking the database connection or counting DB queries during a bulk permission sync. The session `DELETE` query should appear exactly once (per 1,000 users chunked natively) rather than once per user.

---
*PR created automatically by Jules for task [13768653502288909687](https://jules.google.com/task/13768653502288909687) started by @qisthidev*