### PR TITLE
⚡ Bolt: Optimize bulk database session deletion to avoid N+1 queries

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,6 @@
 ## 2024-05-11 - Optimized Permission Check
 **Learning:** Laravolt's `HasRoleAndPermission` and `Role` models do dynamic query checks or `contains` lookups when `hasPermission` is called. Since permissions are eager-loaded, doing a `contains` operation manually can bypass `app(config(...))` overhead and Model instantiation.
 **Action:** Overrode `_hasPermission` in models to utilize eager-loaded relations properly.
+## 2024-05-11 - Bulk Database Session Deletion
+**Learning:** `AccessControlInvalidator::deleteDatabaseSessions` performed an individual database deletion for each user to remove their sessions. In a large bulk operation, this caused N+1 database deletions and repeatedly executed `Schema::hasTable` and `Schema::hasColumn` check queries.
+**Action:** Overrode `invalidateUsers` to accumulate an array of user IDs, extracted `Cache::forget` to a DRY helper, and passed the array down. Used `array_chunk` on the ids to prevent parameter binding limits, combined with `whereIn(...)->delete()` to optimize database deletions from O(N) queries down to O(1) batched queries.

--- a/src/Platform/Services/AccessControlInvalidator.php
+++ b/src/Platform/Services/AccessControlInvalidator.php
@@ -16,20 +16,33 @@ class AccessControlInvalidator
     {
         $userId = $user->getKey();
 
-        Cache::forget("users.{$userId}.permissions");
+        $this->forgetUserCache($userId);
         $this->deleteDatabaseSessions($userId);
     }
 
     public function invalidateUsers(iterable $users): void
     {
+        $userIds = [];
+
         foreach ($users as $user) {
             if ($user instanceof Model) {
-                $this->invalidateUser($user);
+                $userId = $user->getKey();
+                $this->forgetUserCache($userId);
+                $userIds[] = $userId;
             }
+        }
+
+        if (! empty($userIds)) {
+            $this->deleteDatabaseSessions($userIds);
         }
     }
 
-    protected function deleteDatabaseSessions(mixed $userId): void
+    protected function forgetUserCache(mixed $userId): void
+    {
+        Cache::forget("users.{$userId}.permissions");
+    }
+
+    protected function deleteDatabaseSessions(mixed $userIds): void
     {
         try {
             $connection = config('session.connection');
@@ -40,7 +53,13 @@ class AccessControlInvalidator
                 return;
             }
 
-            DB::connection($connection)->table($table)->where('user_id', $userId)->delete();
+            $ids = (array) $userIds;
+
+            // ⚡ Bolt: Chunk the IDs to prevent database driver parameter limit exceptions
+            // and use a single bulk delete instead of N queries
+            foreach (array_chunk($ids, 500) as $chunk) {
+                DB::connection($connection)->table($table)->whereIn('user_id', $chunk)->delete();
+            }
         } catch (Throwable) {
             // Session invalidation is best-effort because Laravolt can run with
             // non-database session drivers or applications without session table.


### PR DESCRIPTION
💡 **What:** 
Optimized `AccessControlInvalidator::invalidateUsers()` to execute a batched database deletion. Extracted the user cache invalidation step into a DRY helper method, accumulated an array of user IDs from the iterator, and updated `deleteDatabaseSessions()` to accept an array of IDs. The deletion utilizes `array_chunk()` to prevent exceeding parameter limits and `whereIn(...)->delete()` to batch the database updates.

🎯 **Why:** 
Previously, `invalidateUsers()` looped through an iterable and sequentially called `invalidateUser()`. For each user, `deleteDatabaseSessions()` was invoked, which executed redundant `Schema::hasTable` operations and individual `DELETE` queries, causing an N+1 database bottleneck during bulk access control invalidation.

📊 **Impact:** 
Changes database queries from O(N) to O(1) batched query operations for database sessions. Significantly reduces database load during mass role assignment or invalidations.

🔬 **Measurement:** 
Verification includes ensuring tests run as expected. No regressions found when processing single users. Bulk actions (e.g. invalidating hundreds of user sessions concurrently) will reflect the improved speed via standard database metrics tracking the number of `DELETE` queries.

---
*PR created automatically by Jules for task [10781903076704474249](https://jules.google.com/task/10781903076704474249) started by @qisthidev*