### PR TITLE
⚡ Bolt: Optimize bulk database session invalidation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,6 @@
 ## 2024-05-11 - Optimized Permission Check
 **Learning:** Laravolt's `HasRoleAndPermission` and `Role` models do dynamic query checks or `contains` lookups when `hasPermission` is called. Since permissions are eager-loaded, doing a `contains` operation manually can bypass `app(config(...))` overhead and Model instantiation.
 **Action:** Overrode `_hasPermission` in models to utilize eager-loaded relations properly.
+## 2024-06-25 - Bulk Invalidations Require Centralized Cache Handling
+**Learning:** When batching operations like `whereIn()->delete()` to solve N+1 problems inside loops, non-batchable operations like cache eviction (`Cache::forget`) often end up duplicating logic between singular (`invalidateUser`) and plural (`invalidateUsers`) methods.
+**Action:** Always extract single-record side effects (like cache eviction) into a shared protected method when refactoring single-record models to support bulk processing. This keeps both code paths synchronized.

--- a/src/Platform/Services/AccessControlInvalidator.php
+++ b/src/Platform/Services/AccessControlInvalidator.php
@@ -16,21 +16,38 @@ class AccessControlInvalidator
     {
         $userId = $user->getKey();
 
-        Cache::forget("users.{$userId}.permissions");
-        $this->deleteDatabaseSessions($userId);
+        $this->invalidateUserCache($userId);
+        $this->deleteDatabaseSessions([$userId]);
     }
 
     public function invalidateUsers(iterable $users): void
     {
+        $userIds = [];
+
         foreach ($users as $user) {
             if ($user instanceof Model) {
-                $this->invalidateUser($user);
+                $userId = $user->getKey();
+                $this->invalidateUserCache($userId);
+                $userIds[] = $userId;
             }
+        }
+
+        if (! empty($userIds)) {
+            $this->deleteDatabaseSessions($userIds);
         }
     }
 
-    protected function deleteDatabaseSessions(mixed $userId): void
+    protected function invalidateUserCache(mixed $userId): void
     {
+        Cache::forget("users.{$userId}.permissions");
+    }
+
+    protected function deleteDatabaseSessions(array $userIds): void
+    {
+        if (empty($userIds)) {
+            return;
+        }
+
         try {
             $connection = config('session.connection');
             $table = config('session.table', 'sessions');
@@ -40,7 +57,8 @@ class AccessControlInvalidator
                 return;
             }
 
-            DB::connection($connection)->table($table)->where('user_id', $userId)->delete();
+            // ⚡ Bolt: Bulk session deletion using whereIn to prevent N+1 queries
+            DB::connection($connection)->table($table)->whereIn('user_id', $userIds)->delete();
         } catch (Throwable) {
             // Session invalidation is best-effort because Laravolt can run with
             // non-database session drivers or applications without session table.


### PR DESCRIPTION
💡 What: Refactored `AccessControlInvalidator::deleteDatabaseSessions` to accept an array of User IDs and perform a single `whereIn()->delete()` query, and extracted cache invalidation logic into `invalidateUserCache` to prevent N+1 queries.
🎯 Why: The `invalidateUsers` loop was previously executing a separate `DELETE` query (and a separate schema check) for every single user, resulting in a severe N+1 bottleneck when invalidating sessions for large collections of users.
📊 Impact: Reduces database queries from O(N) to O(1) for both the information schema checks and the session table row deletions.
🔬 Measurement: Verify by executing `invalidateUsers` with a large Collection of User models and observing the query logs via Debugbar or Telescope. Only a single batch DELETE query should be executed.

---
*PR created automatically by Jules for task [16744900922231567267](https://jules.google.com/task/16744900922231567267) started by @qisthidev*