### PR TITLE
⚡ Bolt: Fix N+1 query bottleneck in syncPermission and syncRoles

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,6 @@
 ## 2024-05-11 - Optimized Permission Check
 **Learning:** Laravolt's `HasRoleAndPermission` and `Role` models do dynamic query checks or `contains` lookups when `hasPermission` is called. Since permissions are eager-loaded, doing a `contains` operation manually can bypass `app(config(...))` overhead and Model instantiation.
 **Action:** Overrode `_hasPermission` in models to utilize eager-loaded relations properly.
+## 2024-05-11 - Batch fetch relational entities before firstOrCreate inside loops
+**Learning:** In sync algorithms (like syncing permissions or roles from string names), looping and executing `firstOrCreate` individually for each string causes O(N) database queries.
+**Action:** Extract all target string names from the array first, perform a single `whereIn` bulk fetch keyed by lowercase name, and only call `firstOrCreate` on items missing from the pre-fetched collection. This reduces database queries to O(1) for existing entities.

--- a/src/Platform/Concerns/HasRoleAndPermission.php
+++ b/src/Platform/Concerns/HasRoleAndPermission.php
@@ -187,8 +187,24 @@ trait HasRoleAndPermission
 
     protected function resolveRoleIds($roles, bool $createMissing = false): array
     {
-        return collect(is_array($roles) ? $roles : [$roles])
-            ->map(function ($role) use ($createMissing) {
+        $rolesArray = is_array($roles) ? $roles : [$roles];
+
+        // ⚡ Bolt: Extract string names to batch fetch existing roles
+        $stringNames = collect($rolesArray)
+            ->filter(fn ($r) => is_string($r) && ! Str::isUuid($r) && ! is_numeric($r))
+            ->values()
+            ->toArray();
+
+        $existingRoles = collect();
+        if (! empty($stringNames)) {
+            $existingRoles = app(config('laravolt.epicentrum.models.role'))
+                ->whereIn('name', $stringNames)
+                ->get()
+                ->keyBy(fn ($item) => strtolower($item->name));
+        }
+
+        return collect($rolesArray)
+            ->map(function ($role) use ($createMissing, $existingRoles) {
                 if (is_numeric($role)) {
                     return (int) $role;
                 }
@@ -198,10 +214,19 @@ trait HasRoleAndPermission
                 }
 
                 if (is_string($role)) {
-                    $query = app(config('laravolt.epicentrum.models.role'))->where('name', $role);
-                    $role = $createMissing ? $query->firstOrCreate(['name' => $role]) : $query->first();
+                    $lowerName = strtolower($role);
+                    if ($existingRoles->has($lowerName)) {
+                        return $existingRoles->get($lowerName)->getKey();
+                    }
 
-                    return $role?->getKey();
+                    $query = app(config('laravolt.epicentrum.models.role'))->where('name', $role);
+                    $roleObj = $createMissing ? $query->firstOrCreate(['name' => $role]) : $query->first();
+
+                    if ($roleObj) {
+                        $existingRoles->put($lowerName, $roleObj);
+                    }
+
+                    return $roleObj?->getKey();
                 }
 
                 if ($role instanceof Model) {

--- a/src/Platform/Models/Role.php
+++ b/src/Platform/Models/Role.php
@@ -64,7 +64,21 @@ class Role extends Model
 
     public function syncPermission(array $permissions)
     {
-        $ids = collect($permissions)->transform(function ($permission) {
+        // ⚡ Bolt: Extract string names to batch fetch existing permissions
+        $stringNames = collect($permissions)
+            ->filter(fn ($p) => is_string($p) && ! str($p)->isUlid() && ! is_numeric($p))
+            ->values()
+            ->toArray();
+
+        $existingPermissions = collect();
+        if (! empty($stringNames)) {
+            $existingPermissions = app(config('laravolt.epicentrum.models.permission'))
+                ->whereIn('name', $stringNames)
+                ->get()
+                ->keyBy(fn ($item) => strtolower($item->name));
+        }
+
+        $ids = collect($permissions)->transform(function ($permission) use ($existingPermissions) {
             if (is_string($permission) && str($permission)->isUlid()) {
                 return $permission;
             }
@@ -72,7 +86,13 @@ class Role extends Model
                 return (int) $permission;
             }
             if (is_string($permission)) {
+                $lowerName = strtolower($permission);
+                if ($existingPermissions->has($lowerName)) {
+                    return $existingPermissions->get($lowerName)->getKey();
+                }
+
                 $permissionObject = app(config('laravolt.epicentrum.models.permission'))->firstOrCreate(['name' => $permission]);
+                $existingPermissions->put($lowerName, $permissionObject);
 
                 return $permissionObject->getKey();
             }


### PR DESCRIPTION
💡 **What**: Refactored `syncPermission` in `Role.php` and `resolveRoleIds` in `HasRoleAndPermission.php`. When processing an array of string permissions/roles, the code now extracts those names and pre-fetches them from the database using a single `whereIn()` query, indexing them in memory by lowercase name. Inside the mapping loop, it checks the in-memory collection first. `firstOrCreate()` is only called for completely new entries.
🎯 **Why**: When assigning multiple permissions via strings (e.g., `$role->syncPermission(['create', 'edit', 'delete'])`), the previous implementation looped through the array and executed `firstOrCreate` individually for every string. This caused an N+1 query problem, hitting the database once or twice for every element in the array.
📊 **Impact**: Reduces database queries from O(N) to O(1) for existing entities. If you sync 50 permissions, it will perform 1 bulk `SELECT` instead of 50 separate queries, drastically decreasing database load during complex ACL setups or seedings.
🔬 **Measurement**: Verified by ensuring all tests continue to pass and `phpstan` confirms accurate return types. Benchmarks on syncing large role datasets will show 1 DB query per sync operation.

---
*PR created automatically by Jules for task [5068775488018359126](https://jules.google.com/task/5068775488018359126) started by @qisthidev*