### PR TITLE
⚡ Bolt: Optimize Acl permission synchronization

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,9 @@
 ## 2024-05-11 - Optimized Permission Check
 **Learning:** Laravolt's `HasRoleAndPermission` and `Role` models do dynamic query checks or `contains` lookups when `hasPermission` is called. Since permissions are eager-loaded, doing a `contains` operation manually can bypass `app(config(...))` overhead and Model instantiation.
 **Action:** Overrode `_hasPermission` in models to utilize eager-loaded relations properly.
+## 2024-06-09 - N+1 Optimizations vs Events
+**Learning:** While optimizing an N+1 bug using query builder bulk deletes (e.g. ) avoids loops, it bypasses important Eloquent model events (/). These events are critical in ecosystems like Laravolt/Spatie for flushing the permission caches or firing custom listeners.
+**Action:** Always retain individual model loops when invoking  for entities that rely on model events for cache invalidation (like  or ), or fallback to  on the Eloquent model instead of the Query Builder.
+## 2024-06-09 - N+1 Optimizations vs Events
+**Learning:** While optimizing an N+1 bug using query builder bulk deletes (e.g., `whereIn()->delete()`) avoids loops, it bypasses important Eloquent model events (`deleted`/`deleting`). These events are critical in ecosystems like Laravolt/Spatie for flushing the permission caches or firing custom listeners.
+**Action:** Always retain individual model loops when invoking `->delete()` for entities that rely on model events for cache invalidation (like `Permission` or `Role`), or fallback to `destroy()` on the Eloquent model instead of the Query Builder.

--- a/src/Platform/Services/Acl.php
+++ b/src/Platform/Services/Acl.php
@@ -38,40 +38,56 @@ class Acl
 
     public function syncPermission($refresh = false): Collection
     {
-        return DB::transaction(function () use ($refresh) {
-            if ($refresh) {
-                Schema::disableForeignKeyConstraints();
-                app(config('laravolt.epicentrum.models.permission'))->truncate();
-                Schema::enableForeignKeyConstraints();
-            }
-
-            $items = collect();
-            foreach ($this->permissions() as $name) {
-                $permission = app(config('laravolt.epicentrum.models.permission'))->firstOrNew(['name' => $name]);
-                $status = 'No Change';
-
-                if (! $permission->exists) {
-                    $permission->save();
-                    $status = 'New';
+        return DB::transaction(
+            function () use ($refresh) {
+                if ($refresh) {
+                    Schema::disableForeignKeyConstraints();
+                    app(config('laravolt.epicentrum.models.permission'))->truncate();
+                    Schema::enableForeignKeyConstraints();
                 }
 
-                $items->push(['id' => $permission->getKey(), 'name' => $name, 'status' => $status]);
+                $items = collect();
+                $permissions = $this->permissions();
+                $permissionModel = app(config('laravolt.epicentrum.models.permission'));
+
+                // Bulk check existing permissions to avoid N+1 querying inside the loop
+                $existingPermissions = collect();
+                if (!empty($permissions)) {
+                    $existingPermissions = $permissionModel->whereIn('name', $permissions)->get()->keyBy('name');
+                }
+
+                foreach ($permissions as $name) {
+                    $status = 'No Change';
+
+                    if ($existingPermissions->has($name)) {
+                        $permission = $existingPermissions->get($name);
+                    } else {
+                        $permission = $permissionModel->newInstance(['name' => $name]);
+                        $permission->save();
+                        $status = 'New';
+                    }
+
+                    $items->push(['id' => $permission->getKey(), 'name' => $name, 'status' => $status]);
+                }
+
+                // delete unused permissions
+                // Original logic used `$permissions + ['*']` where $permissions was an array, but standard array merge is safer
+                $permissionsToDelete = array_merge($this->permissions(), ['*']);
+                $unusedPermissions = $permissionModel
+                    ->whereNotIn('name', $permissionsToDelete)
+                    ->get();
+
+                if ($unusedPermissions->isNotEmpty()) {
+                    foreach ($unusedPermissions as $permission) {
+                        $items->push(['id' => $permission->getKey(), 'name' => $permission->name, 'status' => 'Deleted']);
+                        $permission->delete();
+                    }
+                }
+
+                $items = $items->sortBy('name');
+
+                return $items;
             }
-
-            // delete unused permissions
-            $permissions = $this->permissions() + ['*'];
-            $unusedPermissions = app(config('laravolt.epicentrum.models.permission'))
-                ->whereNotIn('name', $permissions)
-                ->get();
-
-            foreach ($unusedPermissions as $permission) {
-                $items->push(['id' => $permission->getKey(), 'name' => $permission->name, 'status' => 'Deleted']);
-                $permission->delete();
-            }
-
-            $items = $items->sortBy('name');
-
-            return $items;
-        });
+        );
     }
 }


### PR DESCRIPTION
⚡ Bolt: Optimize Acl permission synchronization

💡 What: Replaced the N+1 `firstOrNew` query inside the `Acl::syncPermission` loop with a single bulk query to fetch all existing permissions upfront, leveraging Eloquent's `whereIn()` method. Also fixed a potential bug with overlapping string indices in the array union operator by switching to `array_merge()`.
🎯 Why: The previous implementation performed a new database query for every single registered permission during initialization/sync. This heavily impacts performance on systems with many roles and permissions.
📊 Impact: Reduces database reads during permission synchronization from O(N) to O(1), saving potentially dozens of queries per role assignment/Acl sync operation.
🔬 Measurement: Verify by running tests or enabling query logging during an `Acl::syncPermission()` call to observe a single SELECT query for all permissions instead of an N+1 cascade. Note that we preserved individual deletion for unused permissions to explicitly ensure Eloquent model cache clearing events (`deleting`/`deleted`) fire properly.

---
*PR created automatically by Jules for task [8033879664277682752](https://jules.google.com/task/8033879664277682752) started by @qisthidev*