### PR TITLE
⚡ Bolt: Optimize ACL sync N+1 query and fix wildcard array merge

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,6 @@
 ## 2024-05-11 - Optimized Permission Check
 **Learning:** Laravolt's `HasRoleAndPermission` and `Role` models do dynamic query checks or `contains` lookups when `hasPermission` is called. Since permissions are eager-loaded, doing a `contains` operation manually can bypass `app(config(...))` overhead and Model instantiation.
 **Action:** Overrode `_hasPermission` in models to utilize eager-loaded relations properly.
+## 2024-05-18 - Optimized N+1 Query in ACL Sync and Fixed Array Union Bug
+**Learning:** During permission sync, fetching existing records via `firstOrNew` inside a loop creates an N+1 query problem. Pre-fetching all expected records into a keyed Collection (using `strtolower` to prevent case mismatches) turns O(N) `SELECT` queries into O(1). Additionally, PHP's array union (`+`) ignores values from the right-hand array if the numeric index exists on the left-hand array, which can inadvertently skip items (like wildcard permissions) when merging.
+**Action:** Always pre-fetch records into a Collection (`whereIn(...)->get()->keyBy(...)`) when synchronizing relationships or iterating through names. Avoid using array unions (`+`) with numerically indexed arrays; instead, use `array_merge` or `$array[] = 'value'`.

--- a/src/Platform/Services/Acl.php
+++ b/src/Platform/Services/Acl.php
@@ -38,40 +38,53 @@ class Acl
 
     public function syncPermission($refresh = false): Collection
     {
-        return DB::transaction(function () use ($refresh) {
-            if ($refresh) {
-                Schema::disableForeignKeyConstraints();
-                app(config('laravolt.epicentrum.models.permission'))->truncate();
-                Schema::enableForeignKeyConstraints();
-            }
-
-            $items = collect();
-            foreach ($this->permissions() as $name) {
-                $permission = app(config('laravolt.epicentrum.models.permission'))->firstOrNew(['name' => $name]);
-                $status = 'No Change';
-
-                if (! $permission->exists) {
-                    $permission->save();
-                    $status = 'New';
+        return DB::transaction(
+            function () use ($refresh) {
+                if ($refresh) {
+                    Schema::disableForeignKeyConstraints();
+                    app(config('laravolt.epicentrum.models.permission'))->truncate();
+                    Schema::enableForeignKeyConstraints();
                 }
 
-                $items->push(['id' => $permission->getKey(), 'name' => $name, 'status' => $status]);
+                $items = collect();
+
+                // ⚡ Bolt: Bulk fetch existing permissions to prevent N+1 queries during sync
+                $existingPermissions = app(config('laravolt.epicentrum.models.permission'))
+                    ->whereIn('name', $this->permissions())
+                    ->get()
+                    ->keyBy(fn ($item) => strtolower((string) $item->name));
+
+                foreach ($this->permissions() as $name) {
+                    $status = 'No Change';
+                    $key = strtolower((string) $name);
+
+                    if ($existingPermissions->has($key)) {
+                        $permission = $existingPermissions->get($key);
+                    } else {
+                        $permission = app(config('laravolt.epicentrum.models.permission'))->firstOrCreate(['name' => $name]);
+                        $status = 'New';
+                    }
+
+                    $items->push(['id' => $permission->getKey(), 'name' => $name, 'status' => $status]);
+                }
+
+                // delete unused permissions
+                // Fix: avoid array union bug which ignores values if index exists on the left
+                $permissions = $this->permissions();
+                $permissions[] = '*';
+                $unusedPermissions = app(config('laravolt.epicentrum.models.permission'))
+                    ->whereNotIn('name', $permissions)
+                    ->get();
+
+                foreach ($unusedPermissions as $permission) {
+                    $items->push(['id' => $permission->getKey(), 'name' => $permission->name, 'status' => 'Deleted']);
+                    $permission->delete();
+                }
+
+                $items = $items->sortBy('name');
+
+                return $items;
             }
-
-            // delete unused permissions
-            $permissions = $this->permissions() + ['*'];
-            $unusedPermissions = app(config('laravolt.epicentrum.models.permission'))
-                ->whereNotIn('name', $permissions)
-                ->get();
-
-            foreach ($unusedPermissions as $permission) {
-                $items->push(['id' => $permission->getKey(), 'name' => $permission->name, 'status' => 'Deleted']);
-                $permission->delete();
-            }
-
-            $items = $items->sortBy('name');
-
-            return $items;
-        });
+        );
     }
 }


### PR DESCRIPTION
⚡ Bolt: Optimize ACL sync N+1 query and fix wildcard array merge

* 💡 What: Replaced individual `firstOrNew` calls with a bulk pre-fetch using `whereIn()->get()->keyBy(...)`. Also fixed an array union bug (`$this->permissions() + ['*']`) by using explicit array append.
* 🎯 Why: To eliminate an N+1 query bottleneck during permission synchronization and to prevent the accidental omission of wildcard permissions during unused permission cleanup.
* 📊 Impact: Reduces database `SELECT` round-trips from O(N) to O(1) for existing permissions, resulting in significantly faster syncing when many permissions exist.
* 🔬 Measurement: Observe query logs via Debugbar or Telescope during the `syncPermission` process to verify only one `SELECT` is executed for pre-existing permissions.

---
*PR created automatically by Jules for task [923751125248224225](https://jules.google.com/task/923751125248224225) started by @qisthidev*