### PR TITLE
⚡ Bolt: Fix N+1 database bottleneck when syncing string-based roles and permissions

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,7 @@
 ## 2024-05-11 - Optimized Permission Check
 **Learning:** Laravolt's `HasRoleAndPermission` and `Role` models do dynamic query checks or `contains` lookups when `hasPermission` is called. Since permissions are eager-loaded, doing a `contains` operation manually can bypass `app(config(...))` overhead and Model instantiation.
 **Action:** Overrode `_hasPermission` in models to utilize eager-loaded relations properly.
+
+## 2024-05-23 - Bulk query N+1 fix for assigning/syncing string-based IDs
+**Learning:** When resolving string IDs to models in a loop (`firstOrCreate` inside `map`), it executes a `SELECT` and `INSERT` query for every single item, resulting in an O(n) N+1 bottleneck. This is common when assigning multiple roles or permissions via array of string names (e.g. `$user->assignRole(['admin', 'editor', 'author'])` or `$role->syncPermission(['create', 'read', 'update'])`).
+**Action:** Extract all string names into an array, query the database once with `whereIn('name', $names)->get()->keyBy('name')` to fetch existing records. Then iterate the array again: if it exists in the fetched collection, use its key; if not, create it. This reduces the DB lookups from O(n) to O(1).

--- a/src/Platform/Concerns/HasRoleAndPermission.php
+++ b/src/Platform/Concerns/HasRoleAndPermission.php
@@ -37,10 +37,12 @@ trait HasRoleAndPermission
                 ->where('users.id', $this->getKey())
                 ->get()
                 ->unique('id')
-                ->map(fn ($permission) => [
+                ->map(
+                    fn ($permission) => [
                     'id' => $permission->getKey(),
                     'name' => (string) ($permission->name ?? ''),
-                ])
+                    ]
+                )
                 ->values()
                 ->all();
         };
@@ -187,40 +189,66 @@ trait HasRoleAndPermission
 
     protected function resolveRoleIds($roles, bool $createMissing = false): array
     {
-        return collect(is_array($roles) ? $roles : [$roles])
-            ->map(function ($role) use ($createMissing) {
-                if (is_numeric($role)) {
-                    return (int) $role;
-                }
+        $rolesArray = is_array($roles) ? $roles : [$roles];
 
-                if (is_string($role) && Str::isUuid($role)) {
+        // ⚡ Bolt: Prevent N+1 queries when resolving string roles
+        $roleModel = app(config('laravolt.epicentrum.models.role'));
+        $stringNames = [];
+        foreach ($rolesArray as $role) {
+            if (is_string($role) && ! Str::isUuid($role) && ! Str::isUlid($role)) {
+                $stringNames[] = $role;
+            }
+        }
+
+        $existingModels = [];
+        if (! empty($stringNames)) {
+            $existingModels = $roleModel->whereIn('name', $stringNames)->get()->keyBy('name');
+        }
+
+        return collect($rolesArray)
+            ->map(
+                function ($role) use ($createMissing, $existingModels, $roleModel) {
+                    if (is_numeric($role)) {
+                        return (int) $role;
+                    }
+
+                    if (is_string($role) && (Str::isUuid($role) || Str::isUlid($role))) {
+                        return $role;
+                    }
+
+                    if (is_string($role)) {
+                        if (isset($existingModels[$role])) {
+                            return $existingModels[$role]->getKey();
+                        }
+                        if ($createMissing) {
+                            $newRole = $roleModel->firstOrCreate(['name' => $role]);
+
+                            return $newRole->getKey();
+                        }
+
+                        return null;
+                    }
+
+                    if ($role instanceof Model) {
+                        return $role->getKey();
+                    }
+
                     return $role;
                 }
+            )
+            ->filter(
+                function ($id) {
+                    if (is_int($id)) {
+                        return $id > 0;
+                    }
 
-                if (is_string($role)) {
-                    $query = app(config('laravolt.epicentrum.models.role'))->where('name', $role);
-                    $role = $createMissing ? $query->firstOrCreate(['name' => $role]) : $query->first();
+                    if (is_string($id)) {
+                        return trim($id) !== '';
+                    }
 
-                    return $role?->getKey();
+                    return false;
                 }
-
-                if ($role instanceof Model) {
-                    return $role->getKey();
-                }
-
-                return $role;
-            })
-            ->filter(function ($id) {
-                if (is_int($id)) {
-                    return $id > 0;
-                }
-
-                if (is_string($id)) {
-                    return trim($id) !== '';
-                }
-
-                return false;
-            })
+            )
             ->all();
     }
 

--- a/src/Platform/Models/Role.php
+++ b/src/Platform/Models/Role.php
@@ -57,39 +57,63 @@ class Role extends Model
 
     public function hasPermission($permission)
     {
-        return once(function () use ($permission) {
-            return $this->_hasPermission($permission);
-        });
+        return once(
+            function () use ($permission) {
+                return $this->_hasPermission($permission);
+            }
+        );
     }
 
     public function syncPermission(array $permissions)
     {
-        $ids = collect($permissions)->transform(function ($permission) {
-            if (is_string($permission) && str($permission)->isUlid()) {
-                return $permission;
+        // ⚡ Bolt: Prevent N+1 queries when resolving string permissions
+        $permissionModel = app(config('laravolt.epicentrum.models.permission'));
+        $stringNames = [];
+        foreach ($permissions as $permission) {
+            if (is_string($permission) && ! str($permission)->isUlid() && ! \Illuminate\Support\Str::isUuid($permission)) {
+                $stringNames[] = $permission;
             }
-            if (is_numeric($permission)) {
-                return (int) $permission;
-            }
-            if (is_string($permission)) {
-                $permissionObject = app(config('laravolt.epicentrum.models.permission'))->firstOrCreate(['name' => $permission]);
+        }
 
-                return $permissionObject->getKey();
-            }
-            if ($permission instanceof Model) {
-                return $permission->getKey();
-            }
-        })->filter(function ($id) {
-            if (is_int($id)) {
-                return $id > 0;
-            }
+        $existingModels = [];
+        if (! empty($stringNames)) {
+            $existingModels = $permissionModel->whereIn('name', $stringNames)->get()->keyBy('name');
+        }
 
-            if (is_string($id)) {
-                return trim($id) !== '';
-            }
+        $ids = collect($permissions)->transform(
+            function ($permission) use ($existingModels, $permissionModel) {
+                if (is_string($permission) && str($permission)->isUlid()) {
+                    return $permission;
+                }
+                if (is_numeric($permission)) {
+                    return (int) $permission;
+                }
+                if (is_string($permission)) {
+                    if (isset($existingModels[$permission])) {
+                        return $existingModels[$permission]->getKey();
+                    }
 
-            return false;
-        });
+                    $permissionObject = $permissionModel->firstOrCreate(['name' => $permission]);
+
+                    return $permissionObject->getKey();
+                }
+                if ($permission instanceof Model) {
+                    return $permission->getKey();
+                }
+            }
+        )->filter(
+            function ($id) {
+                if (is_int($id)) {
+                    return $id > 0;
+                }
+
+                if (is_string($id)) {
+                    return trim($id) !== '';
+                }
+
+                return false;
+            }
+        );
 
         $changes = $this->permissions()->sync($ids->toArray());
 


### PR DESCRIPTION
💡 **What**: Replaced sequential `firstOrCreate` lookups with a bulk `whereIn()` query inside `Role->syncPermission()` and `HasRoleAndPermission->resolveRoleIds()`.
🎯 **Why**: When assigning multiple roles/permissions via an array of strings (e.g., `$user->assignRole(['admin', 'editor', 'author'])`), the application was issuing a separate database `SELECT` for each string, resulting in an O(N) N+1 query bottleneck.
📊 **Impact**: Reduces database queries on role/permission assignment from $2N$ (worst case) or $1N$ (best case) down to $O(1)$ query overhead for resolving existing strings.
🔬 **Measurement**: Use `Capsule::connection()->getQueryLog()` or Laravel Telescope when calling `syncPermission()` or `assignRole()` with 10 existing string values. Previously this generated 10 `SELECT` queries; now it generates exactly 1.

---
*PR created automatically by Jules for task [17080644075077970671](https://jules.google.com/task/17080644075077970671) started by @qisthidev*