### PR TITLE
⚡ Bolt: Optimize Acl::syncPermission() batching and fix array union bug

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,6 @@
 ## 2024-05-11 - Optimized Permission Check
 **Learning:** Laravolt's `HasRoleAndPermission` and `Role` models do dynamic query checks or `contains` lookups when `hasPermission` is called. Since permissions are eager-loaded, doing a `contains` operation manually can bypass `app(config(...))` overhead and Model instantiation.
 **Action:** Overrode `_hasPermission` in models to utilize eager-loaded relations properly.
+## 2024-05-12 - ACL Event Dispatch Safety During Bulk Delete
+**Learning:** While `whereIn()->delete()` correctly solves N+1 delete queries, Laravolt's ACL caching heavily depends on Eloquent events like `deleting`/`deleted` being fired on the `Permission` model to accurately invalidate permission caches and detach related roles/users. If bulk deletion bypasses these events, the system will retain stale cache data and orphaned pivot entries.
+**Action:** When optimizing loop deletions in highly integrated systems like ACL packages, prioritize correct event dispatch over raw bulk-query performance. Iterative model deletion is required unless mass cache invalidation is explicitly implemented as a post-action.

--- a/src/Platform/Services/Acl.php
+++ b/src/Platform/Services/Acl.php
@@ -38,40 +38,55 @@ class Acl
 
     public function syncPermission($refresh = false): Collection
     {
-        return DB::transaction(function () use ($refresh) {
-            if ($refresh) {
-                Schema::disableForeignKeyConstraints();
-                app(config('laravolt.epicentrum.models.permission'))->truncate();
-                Schema::enableForeignKeyConstraints();
-            }
-
-            $items = collect();
-            foreach ($this->permissions() as $name) {
-                $permission = app(config('laravolt.epicentrum.models.permission'))->firstOrNew(['name' => $name]);
-                $status = 'No Change';
-
-                if (! $permission->exists) {
-                    $permission->save();
-                    $status = 'New';
+        return DB::transaction(
+            function () use ($refresh) {
+                if ($refresh) {
+                    Schema::disableForeignKeyConstraints();
+                    app(config('laravolt.epicentrum.models.permission'))->truncate();
+                    Schema::enableForeignKeyConstraints();
                 }
 
-                $items->push(['id' => $permission->getKey(), 'name' => $name, 'status' => $status]);
+                $items = collect();
+                $permissionNames = $this->permissions();
+
+                // ⚡ Bolt: Prevent N+1 queries by pre-fetching existing permissions
+                $existingPermissions = app(config('laravolt.epicentrum.models.permission'))
+                    ->whereIn('name', $permissionNames)
+                    ->get()
+                    ->keyBy(fn($item) => strtolower($item->name));
+
+                foreach ($permissionNames as $name) {
+                    $permission = $existingPermissions->get(strtolower($name));
+                    $status = 'No Change';
+
+                    if (! $permission) {
+                        // ⚡ Bolt: Insert fallback
+                        $permission = app(config('laravolt.epicentrum.models.permission'))->firstOrCreate(['name' => $name]);
+                        $status = 'New';
+                    }
+
+                    $items->push(['id' => $permission->getKey(), 'name' => $name, 'status' => $status]);
+                }
+
+                // delete unused permissions
+                // ⚡ Bolt: Fix array collision by appending instead of union on numerically indexed array
+                $permissionsToKeep = $permissionNames;
+                $permissionsToKeep[] = '*';
+
+                $unusedPermissions = app(config('laravolt.epicentrum.models.permission'))
+                    ->whereNotIn('name', $permissionsToKeep)
+                    ->get();
+
+                foreach ($unusedPermissions as $permission) {
+                    $items->push(['id' => $permission->getKey(), 'name' => $permission->name, 'status' => 'Deleted']);
+                    // ⚡ Bolt: Keep individual deletion to trigger Eloquent events and avoid stale ACL cache issues
+                    $permission->delete();
+                }
+
+                $items = $items->sortBy('name');
+
+                return $items;
             }
-
-            // delete unused permissions
-            $permissions = $this->permissions() + ['*'];
-            $unusedPermissions = app(config('laravolt.epicentrum.models.permission'))
-                ->whereNotIn('name', $permissions)
-                ->get();
-
-            foreach ($unusedPermissions as $permission) {
-                $items->push(['id' => $permission->getKey(), 'name' => $permission->name, 'status' => 'Deleted']);
-                $permission->delete();
-            }
-
-            $items = $items->sortBy('name');
-
-            return $items;
-        });
+        );
     }
 }


### PR DESCRIPTION
💡 What
Refactored `Laravolt\Platform\Services\Acl::syncPermission()` to pre-fetch existing permissions into memory and query missing permissions using `firstOrCreate()`. Also fixed a bug where the `*` permission was ignored during deletions due to numerical index collision with the `+` operator.

🎯 Why
When registering multiple permissions, the previous implementation executed a dynamic `firstOrNew` query and subsequent `save` query for every single permission in an N+1 loop. Additionally, the `+ ['*']` array union dropped the wildcard if the source array already possessed index 0, incorrectly causing the `*` permission to be flagged for deletion during syncing.

📊 Impact
Reduces database reads dramatically from `O(N)` queries to `O(1)` bulk read for existing permissions. Prevents `*` permission detachment.

🔬 Measurement
Verify by running `DB_CONNECTION=sqlite DB_DATABASE=:memory: php vendor/bin/phpunit tests/Feature/Acl/AclServiceTest.php`. The test suite execution query counts will reflect the reduction in `SELECT` statements during batch permission syncing.

---
*PR created automatically by Jules for task [7645705164571753724](https://jules.google.com/task/7645705164571753724) started by @qisthidev*