### PR TITLE
⚡ Bolt: Optimize Permission Controller bulk updates with CASE statements

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,6 @@
 ## 2024-05-11 - Optimized Permission Check
 **Learning:** Laravolt's `HasRoleAndPermission` and `Role` models do dynamic query checks or `contains` lookups when `hasPermission` is called. Since permissions are eager-loaded, doing a `contains` operation manually can bypass `app(config(...))` overhead and Model instantiation.
 **Action:** Overrode `_hasPermission` in models to utilize eager-loaded relations properly.
+## 2024-06-24 - Bulk Permission Updates
+**Learning:** Permission update loops can hit N+1 update bottlenecks. You can optimize this by switching from Eloquent looping updates to a single bulk SQL query using a `CASE` statement. When doing this, be sure to update `updated_at` manually since the raw SQL bypasses Eloquent lifecycle events. Chunking prevents exceeding DB parameter limits.
+**Action:** Use SQL `CASE` statements constructed safely with grammar and bindings to batch update multiple records in high-throughput endpoints.

--- a/src/Epicentrum/Http/Controllers/PermissionController.php
+++ b/src/Epicentrum/Http/Controllers/PermissionController.php
@@ -19,8 +19,51 @@ class PermissionController extends Controller
 
     public function update()
     {
-        foreach (request('permission', []) as $key => $description) {
-            config('laravolt.epicentrum.models.permission')::whereId($key)->update(['description' => $description]);
+        $permissions = request('permission', []);
+
+        if (!empty($permissions)) {
+            $modelClass = config('laravolt.epicentrum.models.permission');
+            /** @var \Illuminate\Database\Eloquent\Model $model */
+            $model = new $modelClass();
+            $connection = $model->getConnection();
+            $grammar = $connection->getQueryGrammar();
+
+            $table = $grammar->wrapTable($model->getTable());
+            $idColumn = $grammar->wrap($model->getKeyName());
+            $descColumn = $grammar->wrap('description');
+
+            $updatedAtColumn = $model->usesTimestamps() && ! is_null($model->getUpdatedAtColumn())
+                ? $grammar->wrap($model->getUpdatedAtColumn())
+                : null;
+
+            // Process in chunks to avoid database parameter limits
+            foreach (array_chunk($permissions, 300, true) as $chunk) {
+                $cases = [];
+                $bindings = [];
+                $ids = [];
+
+                foreach ($chunk as $id => $description) {
+                    $cases[] = "WHEN {$idColumn} = ? THEN ?";
+                    $bindings[] = $id;
+                    $bindings[] = $description;
+                    $ids[] = $id;
+                }
+
+                $casesSql = implode(' ', $cases);
+                $placeholders = implode(', ', array_fill(0, count($ids), '?'));
+
+                $sql = "UPDATE {$table} SET {$descColumn} = CASE {$casesSql} ELSE {$descColumn} END";
+
+                if ($updatedAtColumn) {
+                    $sql .= ", {$updatedAtColumn} = ?";
+                    $bindings[] = $model->freshTimestampString();
+                }
+
+                $sql .= " WHERE {$idColumn} IN ({$placeholders})";
+                $bindings = array_merge($bindings, $ids);
+
+                $connection->update($sql, $bindings);
+            }
         }
 
         return redirect()->back()->withSuccess('Permission updated');


### PR DESCRIPTION
💡 **What**: Refactored the `update` method in `PermissionController` to use a chunked, bulk `UPDATE` query utilizing a SQL `CASE` statement, instead of iterating over every single permission array element to issue individual `update()` statements.

🎯 **Why**: When a large number of permissions exist, the form submission previously issued `N` individual `UPDATE` queries to the database. This acts as a significant database bottleneck (the N+1 update problem).

📊 **Impact**: Reduces database round-trips from O(N) to O(N/300) when updating permissions. For instance, saving 500 permissions previously required 500 individual queries; it now uses only 2 queries, leading to markedly faster page loads during save operations and far lower load on the database server.

🔬 **Measurement**: Submitting the edit permissions form with multiple permissions will now reflect only the bulk `UPDATE` queries in query logging (e.g. via Laravel Debugbar or Telescope) instead of a sequence of `UPDATE permissions SET description = ... WHERE id = ...` queries for every item. Testing confirmed syntax logic works perfectly.

---
*PR created automatically by Jules for task [16173709943426312205](https://jules.google.com/task/16173709943426312205) started by @qisthidev*