### PR TITLE
⚡ Bolt: Optimize AccessControlInvalidator to bulk delete database sessions

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,6 @@
 ## 2024-05-11 - Optimized Permission Check
 **Learning:** Laravolt's `HasRoleAndPermission` and `Role` models do dynamic query checks or `contains` lookups when `hasPermission` is called. Since permissions are eager-loaded, doing a `contains` operation manually can bypass `app(config(...))` overhead and Model instantiation.
 **Action:** Overrode `_hasPermission` in models to utilize eager-loaded relations properly.
+## 2024-05-11 - Bulk Database Session Deletion
+**Learning:** In Laravolt `AccessControlInvalidator`, deleting sessions for an array of users triggers an N+1 query (`where('user_id', $id)->delete()`). Refactoring this to gather all user IDs first and use a single `whereIn('user_id', $ids)->delete()` eliminates the bottleneck. Also, Laravel `Cache::forget` natively does not support bulk invalidation for keys with different variables, so we must loop for caches while bulk querying for the database.
+**Action:** Extract user IDs within a loop to clear caches and then execute a single database operation (`whereIn()->delete()`) when bulk operations combine caching and database mutations. Always use `is_iterable` in protected DB abstraction functions to keep backwards compatibility.

--- a/src/Platform/Services/AccessControlInvalidator.php
+++ b/src/Platform/Services/AccessControlInvalidator.php
@@ -16,20 +16,34 @@ class AccessControlInvalidator
     {
         $userId = $user->getKey();
 
-        Cache::forget("users.{$userId}.permissions");
+        $this->forgetUserCache($userId);
         $this->deleteDatabaseSessions($userId);
     }
 
     public function invalidateUsers(iterable $users): void
     {
+        $userIds = [];
+
         foreach ($users as $user) {
             if ($user instanceof Model) {
-                $this->invalidateUser($user);
+                $userId = $user->getKey();
+                $this->forgetUserCache($userId);
+                $userIds[] = $userId;
             }
+        }
+
+        if (! empty($userIds)) {
+            $this->deleteDatabaseSessions($userIds);
         }
     }
 
-    protected function deleteDatabaseSessions(mixed $userId): void
+    protected function forgetUserCache(mixed $userId): void
+    {
+        // ⚡ Bolt: Cache doesn't natively support bulk invalidation
+        Cache::forget("users.{$userId}.permissions");
+    }
+
+    protected function deleteDatabaseSessions(mixed $userIds): void
     {
         try {
             $connection = config('session.connection');
@@ -40,7 +54,12 @@ class AccessControlInvalidator
                 return;
             }
 
-            DB::connection($connection)->table($table)->where('user_id', $userId)->delete();
+            // ⚡ Bolt: Bulk delete sessions to prevent N+1 queries when invalidating multiple users
+            if (is_iterable($userIds)) {
+                DB::connection($connection)->table($table)->whereIn('user_id', $userIds)->delete();
+            } else {
+                DB::connection($connection)->table($table)->where('user_id', $userIds)->delete();
+            }
         } catch (Throwable) {
             // Session invalidation is best-effort because Laravolt can run with
             // non-database session drivers or applications without session table.


### PR DESCRIPTION
💡 What:
Refactored `AccessControlInvalidator@invalidateUsers` to gather all user IDs into an array and perform a single `whereIn()->delete()` query to drop database sessions instead of executing individual delete queries within a loop.

🎯 Why:
Eliminates an N+1 database query bottleneck when invalidating access control for multiple users simultaneously (such as when assigning a role with existing users).

📊 Impact:
Reduces database session deletion queries from O(N) to O(1) during bulk invalidation.

🔬 Measurement:
Run existing feature tests involving `Role::invalidateAssignedUsersAccessControl()` and monitor database query counts to verify the reduction in `DELETE FROM sessions WHERE user_id = ?` statements.

---
*PR created automatically by Jules for task [328134126813722860](https://jules.google.com/task/328134126813722860) started by @qisthidev*