### PR TITLE
⚡ Bolt: Resolve N+1 query issue in AccessControlInvalidator

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,6 @@
 ## 2024-05-11 - Optimized Permission Check
 **Learning:** Laravolt's `HasRoleAndPermission` and `Role` models do dynamic query checks or `contains` lookups when `hasPermission` is called. Since permissions are eager-loaded, doing a `contains` operation manually can bypass `app(config(...))` overhead and Model instantiation.
 **Action:** Overrode `_hasPermission` in models to utilize eager-loaded relations properly.
+## 2024-05-18 - Bulk Database Invalidations with Schema Checks
+**Learning:** Found an N+1 query loop in `AccessControlInvalidator@invalidateUsers`. The loop issued individual `deleteDatabaseSessions` calls for each user, which in turn performed `Schema::hasTable` checks and a database `delete()` query for every single item.
+**Action:** Always extract loop logic that contains schema/database queries. Group IDs in the loop, execute cache removals (as they aren't easily bulked) in the loop, but then execute a single `whereIn()->delete()` operation for the database deletion outside the loop to significantly minimize database traffic and execution time.

--- a/src/Platform/Services/AccessControlInvalidator.php
+++ b/src/Platform/Services/AccessControlInvalidator.php
@@ -16,20 +16,32 @@ class AccessControlInvalidator
     {
         $userId = $user->getKey();
 
-        Cache::forget("users.{$userId}.permissions");
+        $this->forgetUserCache($userId);
         $this->deleteDatabaseSessions($userId);
     }
 
     public function invalidateUsers(iterable $users): void
     {
+        $userIds = [];
         foreach ($users as $user) {
             if ($user instanceof Model) {
-                $this->invalidateUser($user);
+                $userId = $user->getKey();
+                $this->forgetUserCache($userId);
+                $userIds[] = $userId;
             }
+        }
+
+        if (!empty($userIds)) {
+            $this->deleteDatabaseSessions($userIds);
         }
     }
 
-    protected function deleteDatabaseSessions(mixed $userId): void
+    protected function forgetUserCache(mixed $userId): void
+    {
+        Cache::forget("users.{$userId}.permissions");
+    }
+
+    protected function deleteDatabaseSessions(mixed $userIds): void
     {
         try {
             $connection = config('session.connection');
@@ -40,7 +52,13 @@ class AccessControlInvalidator
                 return;
             }
 
-            DB::connection($connection)->table($table)->where('user_id', $userId)->delete();
+            $query = DB::connection($connection)->table($table);
+            if (is_iterable($userIds)) {
+                $query->whereIn('user_id', $userIds);
+            } else {
+                $query->where('user_id', $userIds);
+            }
+            $query->delete();
         } catch (Throwable) {
             // Session invalidation is best-effort because Laravolt can run with
             // non-database session drivers or applications without session table.


### PR DESCRIPTION
💡 **What**: Refactored `AccessControlInvalidator@invalidateUsers` to gather user IDs and perform a single bulk `whereIn('user_id', $userIds)->delete()` query for session invalidation instead of individual delete queries inside a loop.
🎯 **Why**: Resolves a significant N+1 query performance bottleneck. Each iteration previously caused additional database roundtrips, including hidden schema checks (`Schema::hasTable`), slowing down the invalidation process dramatically for large user arrays.
📊 **Impact**: Reduces database queries from O(N) to O(1) for session deletions during bulk invalidations. Performance improvement scales linearly with the number of users being invalidated.
🔬 **Measurement**: Verify via testing the invalidation of multiple users at once, measuring the database queries executed via Laravel Debugbar or Telescope, which should now show 1 single delete query regardless of the input size.

---
*PR created automatically by Jules for task [3319508594894928107](https://jules.google.com/task/3319508594894928107) started by @qisthidev*