### PR TITLE
⚡ Bolt: Optimize Acl::syncPermission query performance

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,7 @@
 ## 2024-05-11 - Optimized Permission Check
 **Learning:** Laravolt's `HasRoleAndPermission` and `Role` models do dynamic query checks or `contains` lookups when `hasPermission` is called. Since permissions are eager-loaded, doing a `contains` operation manually can bypass `app(config(...))` overhead and Model instantiation.
 **Action:** Overrode `_hasPermission` in models to utilize eager-loaded relations properly.
+
+## 2024-05-18 - Bulk Operations in ACL syncPermission
+**Learning:** In `Laravolt\Platform\Services\Acl`, the `syncPermission` iterated over registered permissions to check existence via `firstOrNew` and save them. Not only did this generate N+1 queries, but using `firstOrNew` followed by `save()` in a loop without catching duplicates opens up race conditions resulting in unique constraint violations in concurrent workflows. Additionally, array union operations (`+`) can swallow indexes if an explicit index collides with sequential indexes during merge operations, such as adding the wildcard `['*']`.
+**Action:** Always refactor model initialization loops in ACL systems to bulk fetch existing records into a keyed Collection first. When persisting missing records based on names, prefer using `firstOrCreate` over `firstOrNew` + `save` to leverage Laravel's built-in transaction safe-guards. Always use `array_merge` over the `+` operator when merging flat arrays in Laravel PHP.

--- a/src/Platform/Services/Acl.php
+++ b/src/Platform/Services/Acl.php
@@ -46,12 +46,23 @@ class Acl
             }
 
             $items = collect();
-            foreach ($this->permissions() as $name) {
-                $permission = app(config('laravolt.epicentrum.models.permission'))->firstOrNew(['name' => $name]);
-                $status = 'No Change';
 
-                if (! $permission->exists) {
-                    $permission->save();
+            // fetch existing permissions in bulk
+            $permissionNames = $this->permissions();
+            $existingPermissions = app(config('laravolt.epicentrum.models.permission'))
+                ->whereIn('name', $permissionNames)
+                ->get()
+                ->keyBy(function ($item) {
+                    return mb_strtolower($item->name);
+                });
+
+            foreach ($permissionNames as $name) {
+                $lowerName = mb_strtolower($name);
+                if ($existingPermissions->has($lowerName)) {
+                    $permission = $existingPermissions->get($lowerName);
+                    $status = 'No Change';
+                } else {
+                    $permission = app(config('laravolt.epicentrum.models.permission'))->firstOrCreate(['name' => $name]);
                     $status = 'New';
                 }
 
@@ -59,7 +70,7 @@ class Acl
             }
 
             // delete unused permissions
-            $permissions = $this->permissions() + ['*'];
+            $permissions = array_merge($permissionNames, ['*']);
             $unusedPermissions = app(config('laravolt.epicentrum.models.permission'))
                 ->whereNotIn('name', $permissions)
                 ->get();


### PR DESCRIPTION
💡 What: 
- Refactored `Acl::syncPermission()` to fetch existing permissions in bulk via a single `whereIn` query and keyed them by name in a Collection for fast in-memory lookups.
- Replaced iterative `firstOrNew()` + `save()` with `firstOrCreate()` for any missing permissions to protect against race conditions.
- Replaced the array union operator `+` with `array_merge()` when adding the `*` wildcard permission.

🎯 Why: 
- Iterating and running individual `firstOrNew` and `save` operations triggered O(N) database queries during system bootstrap/permission sync. 
- Calling `firstOrNew` followed by `save()` is susceptible to race conditions and unique constraint violations when concurrent processes attempt to register permissions.
- The array union operator `+` ignores values from the right side if the key already exists on the left side, which swallowed the wildcard permission if sequential array indexes happened to align.

📊 Impact: 
- Reduces database roundtrips from O(N) queries to O(1) queries for checking existing permissions.
- Drastically reduces query overhead during the `Acl::syncPermission()` bootstrapping step.

🔬 Measurement: 
- Run standard ACL tests or use Laravel Telescope/Debugbar during application boot when permissions are synchronized; you will observe a single `SELECT` query for the bulk check rather than dozens of individual `SELECT` queries.

---
*PR created automatically by Jules for task [14981861080968061876](https://jules.google.com/task/14981861080968061876) started by @qisthidev*