### PR TITLE
⚡ Bolt: Optimize AccessControlInvalidator bulk deletion

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,6 @@
 ## 2024-05-11 - Optimized Permission Check
 **Learning:** Laravolt's `HasRoleAndPermission` and `Role` models do dynamic query checks or `contains` lookups when `hasPermission` is called. Since permissions are eager-loaded, doing a `contains` operation manually can bypass `app(config(...))` overhead and Model instantiation.
 **Action:** Overrode `_hasPermission` in models to utilize eager-loaded relations properly.
+## 2024-05-11 - Batching Database Deletions in Loops
+**Learning:** `AccessControlInvalidator@invalidateUsers` iterated through users and deleted their session manually, triggering a `Schema` check and `DELETE` database query for every user.
+**Action:** Refactored loops that hit the database to extract IDs and batch execute queries via `whereIn`.

--- a/src/Platform/Services/AccessControlInvalidator.php
+++ b/src/Platform/Services/AccessControlInvalidator.php
@@ -15,21 +15,33 @@ class AccessControlInvalidator
     public function invalidateUser(Model $user): void
     {
         $userId = $user->getKey();
-
-        Cache::forget("users.{$userId}.permissions");
+        $this->clearPermissionCache($userId);
         $this->deleteDatabaseSessions($userId);
     }
 
     public function invalidateUsers(iterable $users): void
     {
+        $userIds = [];
+
         foreach ($users as $user) {
             if ($user instanceof Model) {
-                $this->invalidateUser($user);
+                $userId = $user->getKey();
+                $this->clearPermissionCache($userId);
+                $userIds[] = $userId;
             }
+        }
+
+        if (! empty($userIds)) {
+            $this->deleteDatabaseSessions($userIds);
         }
     }
 
-    protected function deleteDatabaseSessions(mixed $userId): void
+    protected function clearPermissionCache(mixed $userId): void
+    {
+        Cache::forget("users.{$userId}.permissions");
+    }
+
+    protected function deleteDatabaseSessions(mixed $userIds): void
     {
         try {
             $connection = config('session.connection');
@@ -40,7 +52,15 @@ class AccessControlInvalidator
                 return;
             }
 
-            DB::connection($connection)->table($table)->where('user_id', $userId)->delete();
+            $query = DB::connection($connection)->table($table);
+
+            if (is_iterable($userIds)) {
+                $query->whereIn('user_id', is_array($userIds) ? $userIds : iterator_to_array($userIds));
+            } else {
+                $query->where('user_id', $userIds);
+            }
+
+            $query->delete();
         } catch (Throwable) {
             // Session invalidation is best-effort because Laravolt can run with
             // non-database session drivers or applications without session table.


### PR DESCRIPTION
💡 What: Refactored `AccessControlInvalidator@invalidateUsers` to extract user IDs in a loop and perform a single batched `deleteDatabaseSessions` call (which now supports iterables/arrays via `whereIn`). Cache invalidation remains in the loop since it doesn't support bulk operations natively.
🎯 Why: Previously, `invalidateUsers` looped over each user and executed `deleteDatabaseSessions` individually. This triggered a `Schema::hasTable`, `Schema::hasColumn`, and a `DELETE` query for every user, causing an N+1 query and schema check bottleneck. 
📊 Impact: Reduces database deletion queries and schema introspection queries from O(N) to O(1) when invalidating multiple users.
🔬 Measurement: Verify by executing the test suite or performing a manual bulk invalidate and tracing the SQL queries executed.

---
*PR created automatically by Jules for task [6656773512988925113](https://jules.google.com/task/6656773512988925113) started by @qisthidev*