### PR TITLE
⚡ Bolt: Bulk delete database sessions during user invalidation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,6 @@
 ## 2024-05-11 - Optimized Permission Check
 **Learning:** Laravolt's `HasRoleAndPermission` and `Role` models do dynamic query checks or `contains` lookups when `hasPermission` is called. Since permissions are eager-loaded, doing a `contains` operation manually can bypass `app(config(...))` overhead and Model instantiation.
 **Action:** Overrode `_hasPermission` in models to utilize eager-loaded relations properly.
+## 2024-05-14 - Prevent N+1 queries during bulk user invalidation
+**Learning:** In `AccessControlInvalidator`, validating users in a bulk iterable loop triggers individual database `DELETE` statements (to remove database sessions) for each user. It also checks `Schema::hasTable` and `Schema::hasColumn` on each loop iteration, resulting in many redundant Information Schema queries.
+**Action:** When performing bulk deletion over an iterable collection of models, separate cache busting (which often doesn't natively support bulk invalidation well) from database queries. Collect primary keys into an array, then execute a single `whereIn()->delete()` and execute the Schema validation steps exactly once prior to the query.

--- a/src/Platform/Services/AccessControlInvalidator.php
+++ b/src/Platform/Services/AccessControlInvalidator.php
@@ -16,20 +16,34 @@ class AccessControlInvalidator
     {
         $userId = $user->getKey();
 
-        Cache::forget("users.{$userId}.permissions");
+        $this->forgetUserCache($userId);
         $this->deleteDatabaseSessions($userId);
     }
 
     public function invalidateUsers(iterable $users): void
     {
+        $userIds = [];
+
         foreach ($users as $user) {
             if ($user instanceof Model) {
-                $this->invalidateUser($user);
+                $userId = $user->getKey();
+                $userIds[] = $userId;
+                $this->forgetUserCache($userId);
             }
+        }
+
+        if (! empty($userIds)) {
+            // ⚡ Bolt: Bulk delete database sessions to prevent N+1 queries
+            $this->deleteDatabaseSessions($userIds);
         }
     }
 
-    protected function deleteDatabaseSessions(mixed $userId): void
+    protected function forgetUserCache(mixed $userId): void
+    {
+        Cache::forget("users.{$userId}.permissions");
+    }
+
+    protected function deleteDatabaseSessions(mixed $userIds): void
     {
         try {
             $connection = config('session.connection');
@@ -40,7 +54,15 @@ class AccessControlInvalidator
                 return;
             }
 
-            DB::connection($connection)->table($table)->where('user_id', $userId)->delete();
+            $query = DB::connection($connection)->table($table);
+
+            if (is_iterable($userIds)) {
+                $query->whereIn('user_id', is_array($userIds) ? $userIds : iterator_to_array($userIds));
+            } else {
+                $query->where('user_id', $userIds);
+            }
+
+            $query->delete();
         } catch (Throwable) {
             // Session invalidation is best-effort because Laravolt can run with
             // non-database session drivers or applications without session table.


### PR DESCRIPTION
💡 **What:** 
Updated `AccessControlInvalidator::invalidateUsers` to gather user IDs and perform a single `whereIn()->delete()` for database sessions, rather than running individual `where()->delete()` queries inside a loop. The cache busting is separated into a `forgetUserCache` protected method, keeping it within the loop iteration logic, while avoiding redundant DB calls and `Schema` validations.

🎯 **Why:** 
When validating multiple users at once (e.g., when a role's permissions change via `app(AccessControlInvalidator::class)->invalidateUsers($this->users()->cursor());`), the previous implementation fired individual `DELETE` and Information Schema checks for every single user, leading to a serious N+1 DB bottleneck on systems with many users per role.

📊 **Impact:** 
Reduces database round-trips from `O(N)` queries down to `O(1)` query for database session deletion during bulk updates. Also avoids `O(N)` information schema queries during the `deleteDatabaseSessions` call.

🔬 **Measurement:** 
Verify with a database listener (e.g. Laravel Debugbar or Telescope). Invalidate a role with 100 users and observe that instead of 100+ `delete` session queries, only one `DELETE FROM sessions WHERE user_id IN (...)` is executed.

---
*PR created automatically by Jules for task [13464665484394598471](https://jules.google.com/task/13464665484394598471) started by @qisthidev*