### PR TITLE
⚡ Bolt: Optimize AccessControlInvalidator N+1 query and schema check

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,6 @@
 ## 2024-05-11 - Optimized Permission Check
 **Learning:** Laravolt's `HasRoleAndPermission` and `Role` models do dynamic query checks or `contains` lookups when `hasPermission` is called. Since permissions are eager-loaded, doing a `contains` operation manually can bypass `app(config(...))` overhead and Model instantiation.
 **Action:** Overrode `_hasPermission` in models to utilize eager-loaded relations properly.
+## 2024-05-11 - AccessControlInvalidator N+1 schema checks
+**Learning:** Laravolt`s `AccessControlInvalidator` calls `invalidateUser` in a loop inside `invalidateUsers`. `invalidateUser` calls `deleteDatabaseSessions` per user, which performs `Schema::hasTable` and `Schema::hasColumn` reflection checks per database iteration, resulting in N+1 schema reflection queries.
+**Action:** Extract database schema reflection checks and deletion queries out of loops. When batched invalidation is required, use `is_iterable` and `whereIn()->delete()` to consolidate operations and avoid repetitive query builder invocations.

--- a/src/Platform/Services/AccessControlInvalidator.php
+++ b/src/Platform/Services/AccessControlInvalidator.php
@@ -16,22 +16,42 @@ class AccessControlInvalidator
     {
         $userId = $user->getKey();
 
-        Cache::forget("users.{$userId}.permissions");
+        $this->clearUserCache($userId);
         $this->deleteDatabaseSessions($userId);
     }
 
     public function invalidateUsers(iterable $users): void
     {
+        $userIds = [];
+
         foreach ($users as $user) {
             if ($user instanceof Model) {
-                $this->invalidateUser($user);
+                $userId = $user->getKey();
+                $this->clearUserCache($userId);
+                $userIds[] = $userId;
             }
+        }
+
+        if (!empty($userIds)) {
+            $this->deleteDatabaseSessions($userIds);
         }
     }
 
-    protected function deleteDatabaseSessions(mixed $userId): void
+    protected function clearUserCache(mixed $userId): void
+    {
+        Cache::forget("users.{$userId}.permissions");
+    }
+
+    protected function deleteDatabaseSessions(mixed $userIds): void
     {
         try {
+            if (is_iterable($userIds)) {
+                $ids = is_array($userIds) ? $userIds : iterator_to_array($userIds);
+                if (empty($ids)) {
+                    return;
+                }
+            }
+
             $connection = config('session.connection');
             $table = config('session.table', 'sessions');
             $schema = Schema::connection($connection);
@@ -40,7 +60,13 @@ class AccessControlInvalidator
                 return;
             }
 
-            DB::connection($connection)->table($table)->where('user_id', $userId)->delete();
+            $query = DB::connection($connection)->table($table);
+
+            if (is_iterable($userIds)) {
+                $query->whereIn('user_id', $ids)->delete();
+            } else {
+                $query->where('user_id', $userIds)->delete();
+            }
         } catch (Throwable) {
             // Session invalidation is best-effort because Laravolt can run with
             // non-database session drivers or applications without session table.


### PR DESCRIPTION
💡 What: Refactored `AccessControlInvalidator::invalidateUsers` and `deleteDatabaseSessions` to batch schema checks and execute a single `WHERE IN` database query for deleting user sessions. Cache invalidation remains iterative via a protected method.
🎯 Why: Iterating over multiple users for invalidation caused an N+1 query issue for the database session `DELETE` statements, compounded by redundant `Schema::hasTable` and `Schema::hasColumn` checks occurring on every iteration loop.
📊 Impact: Reduces database queries from O(N) to O(1) for both the actual session deletions and the schema reflection checks, significantly improving performance when clearing access controls for multiple users.
🔬 Measurement: Run Pest test suite, and check `invalidateUsers` execution when invalidating 10+ users; observe query logs going from 2*N queries to exactly 1 session deletion query + cache checks.

---
*PR created automatically by Jules for task [9554366028883735920](https://jules.google.com/task/9554366028883735920) started by @qisthidev*