### PR TITLE
⚡ Bolt: Optimize bulk permission updates with CASE queries

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,6 @@
 ## 2024-05-11 - Optimized Permission Check
 **Learning:** Laravolt's `HasRoleAndPermission` and `Role` models do dynamic query checks or `contains` lookups when `hasPermission` is called. Since permissions are eager-loaded, doing a `contains` operation manually can bypass `app(config(...))` overhead and Model instantiation.
 **Action:** Overrode `_hasPermission` in models to utilize eager-loaded relations properly.
+## 2024-06-25 - Bulk UPDATE Query Builder with Laravel
+**Learning:** `PermissionController::update` was calling `config('laravolt.epicentrum.models.permission')::whereId($key)->update(...)` in a `foreach` loop, resulting in `N+1` queries for bulk permission updates. By extracting `request('permission', [])` and chunking it, we can resolve the model instance, extract the connection and grammar, and craft a `CASE` statement inside a raw query (`UPDATE ... SET ... = CASE WHEN ...`). Since Eloquent `update` auto-updates `updated_at`, it must be manually appended to the raw query (`usesTimestamps` and `freshTimestampString()`).
+**Action:** When updating a large number of rows iteratively, refactor to chunking and `CASE` conditional updates via the raw Query Builder instance to ensure efficiency, keeping constraints on table and column wrappings via the DB grammar.

--- a/src/Epicentrum/Http/Controllers/PermissionController.php
+++ b/src/Epicentrum/Http/Controllers/PermissionController.php
@@ -10,17 +10,61 @@ class PermissionController extends Controller
 {
     public function edit()
     {
-        $permissions = config('laravolt.epicentrum.models.permission')::all()->sortBy(function ($item) {
-            return mb_strtolower($item->name);
-        });
+        $permissions = config('laravolt.epicentrum.models.permission')::all()->sortBy(
+            function ($item) {
+                return mb_strtolower($item->name);
+            }
+        );
 
         return view('laravolt::permissions.edit', compact('permissions'));
     }
 
     public function update()
     {
-        foreach (request('permission', []) as $key => $description) {
-            config('laravolt.epicentrum.models.permission')::whereId($key)->update(['description' => $description]);
+        $permissions = request('permission', []);
+
+        if (!empty($permissions)) {
+            $modelClass = config('laravolt.epicentrum.models.permission');
+            $model = new $modelClass();
+            $connection = $model->getConnection();
+            $grammar = $connection->getQueryGrammar();
+
+            $table = $grammar->wrapTable($model->getTable());
+            $idColumn = $grammar->wrap($model->getKeyName());
+            $descColumn = $grammar->wrap('description');
+
+            $usesTimestamps = $model->usesTimestamps() && !is_null($model->getUpdatedAtColumn());
+            $updatedAtColumn = $usesTimestamps ? $grammar->wrap($model->getUpdatedAtColumn()) : null;
+
+            $chunks = array_chunk($permissions, 300, true);
+
+            foreach ($chunks as $chunk) {
+                $cases = [];
+                $bindings = [];
+                $ids = [];
+
+                foreach ($chunk as $key => $description) {
+                    $cases[] = "WHEN {$idColumn} = ? THEN ?";
+                    $bindings[] = $key;
+                    $bindings[] = $description;
+                    $ids[] = $key;
+                }
+
+                $casesSql = implode(' ', $cases);
+                $setSql = "{$descColumn} = CASE {$casesSql} ELSE {$descColumn} END";
+
+                if ($usesTimestamps) {
+                    $setSql .= ", {$updatedAtColumn} = ?";
+                    $bindings[] = $model->freshTimestampString();
+                }
+
+                $placeholders = implode(',', array_fill(0, count($ids), '?'));
+                $bindings = array_merge($bindings, $ids);
+
+                $query = "UPDATE {$table} SET {$setSql} WHERE {$idColumn} IN ({$placeholders})";
+
+                $connection->update($query, $bindings);
+            }
         }
 
         return redirect()->back()->withSuccess('Permission updated');


### PR DESCRIPTION
💡 What:
Refactored `PermissionController::update` to replace an N-query `foreach` update loop with a chunked raw `UPDATE` using parameterized `CASE` statements.

🎯 Why:
To solve an N+1 query problem that occurred when bulk-updating permission descriptions, which could negatively impact database performance if many permissions are updated simultaneously.

📊 Impact:
Reduces database round-trips from O(N) to O(1) (per 300 chunks).

🔬 Measurement:
Observe the number of queries fired using Laravel Telescope or Debugbar when submitting the permission edit form. The queries will drop dramatically when editing many roles.

---
*PR created automatically by Jules for task [4296174055575160095](https://jules.google.com/task/4296174055575160095) started by @qisthidev*