### PR TITLE
⚡ Bolt: Optimize bulk database session invalidation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,7 @@
 ## 2024-05-11 - Optimized Permission Check
 **Learning:** Laravolt's `HasRoleAndPermission` and `Role` models do dynamic query checks or `contains` lookups when `hasPermission` is called. Since permissions are eager-loaded, doing a `contains` operation manually can bypass `app(config(...))` overhead and Model instantiation.
 **Action:** Overrode `_hasPermission` in models to utilize eager-loaded relations properly.
+
+## 2024-05-18 - Bulk Invalidation of Database Sessions
+**Learning:** Invalidation routines (like `AccessControlInvalidator::invalidateUsers`) that loop through objects to individually perform query deletions (like session purging) lead to hidden N+1 queries. When batch-deleting database sessions across a large number of users, extracting the IDs and executing a single `whereIn()->delete()` is significantly faster.
+**Action:** Always inspect array iterations that trigger database operations for potential batch-processing opportunities, such as extracting IDs and utilizing `whereIn()`.

--- a/src/Platform/Services/AccessControlInvalidator.php
+++ b/src/Platform/Services/AccessControlInvalidator.php
@@ -14,23 +14,38 @@ class AccessControlInvalidator
 {
     public function invalidateUser(Model $user): void
     {
-        $userId = $user->getKey();
-
-        Cache::forget("users.{$userId}.permissions");
-        $this->deleteDatabaseSessions($userId);
+        $this->invalidateUserCache($user);
+        $this->deleteDatabaseSessions($user->getKey());
     }
 
     public function invalidateUsers(iterable $users): void
     {
+        $userIds = [];
+
         foreach ($users as $user) {
             if ($user instanceof Model) {
-                $this->invalidateUser($user);
+                $this->invalidateUserCache($user);
+                $userIds[] = $user->getKey();
             }
         }
+
+        if (! empty($userIds)) {
+            $this->deleteDatabaseSessions($userIds);
+        }
+    }
+
+    protected function invalidateUserCache(Model $user): void
+    {
+        $userId = $user->getKey();
+        Cache::forget("users.{$userId}.permissions");
     }
 
     protected function deleteDatabaseSessions(mixed $userId): void
     {
+        if (empty($userId)) {
+            return;
+        }
+
         try {
             $connection = config('session.connection');
             $table = config('session.table', 'sessions');
@@ -40,7 +55,14 @@ class AccessControlInvalidator
                 return;
             }
 
-            DB::connection($connection)->table($table)->where('user_id', $userId)->delete();
+            $query = DB::connection($connection)->table($table);
+
+            if (is_iterable($userId)) {
+                $userIdArray = is_array($userId) ? $userId : iterator_to_array($userId);
+                $query->whereIn('user_id', $userIdArray)->delete();
+            } else {
+                $query->where('user_id', $userId)->delete();
+            }
         } catch (Throwable) {
             // Session invalidation is best-effort because Laravolt can run with
             // non-database session drivers or applications without session table.


### PR DESCRIPTION
⚡ Bolt: Optimize bulk database session invalidation

💡 What: Refactored `AccessControlInvalidator::invalidateUsers` to accumulate missing IDs and perform a single `whereIn()->delete()` database operation, while calling a shared helper to invalidate cache items, thereby adhering to DRY principles.
🎯 Why: Iterating over collections of user models and dispatching individual database queries for session deletion results in an N+1 performance bottleneck that drastically impacts the runtime during bulk role/permission invalidation.
📊 Impact: Reduces database execution trips from O(N) queries to a single query when invalidating sessions for an array or cursor of users.
🔬 Measurement: Verified via unit test suite passing successfully and inspecting SQL execution logs.

---
*PR created automatically by Jules for task [7248918215441779614](https://jules.google.com/task/7248918215441779614) started by @qisthidev*