### PR TITLE
⚡ Bolt: Optimize Role::syncPermission N+1 and fix Acl array union bug

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,6 @@
 ## 2024-05-11 - Optimized Permission Check
 **Learning:** Laravolt's `HasRoleAndPermission` and `Role` models do dynamic query checks or `contains` lookups when `hasPermission` is called. Since permissions are eager-loaded, doing a `contains` operation manually can bypass `app(config(...))` overhead and Model instantiation.
 **Action:** Overrode `_hasPermission` in models to utilize eager-loaded relations properly.
+## 2024-05-12 - N+1 Queries in Bulk Operations and Array Union Trap
+**Learning:** `Role::syncPermission()` created N+1 queries by executing `firstOrCreate` individually for every string permission passed. Furthermore, `Acl::syncPermission()` exhibited a subtle bug where the PHP array union operator `+` (`$permissions + ['*']`) ignored `'*'` because index 0 was already populated, potentially causing accidental deletion of the superadmin `'*'` permission.
+**Action:** Always batch-fetch existing records using `whereIn()` before executing loops that create records. Never use the array union `+` operator for appending elements to numerically indexed arrays; use `[] =` or `array_merge()` instead.

--- a/src/Platform/Models/Role.php
+++ b/src/Platform/Models/Role.php
@@ -61,39 +61,70 @@ class Role extends Model
 
     public function hasPermission($permission)
     {
-        return once(function () use ($permission) {
-            return $this->_hasPermission($permission);
-        });
+        return once(
+            function () use ($permission) {
+                return $this->_hasPermission($permission);
+            }
+        );
     }
 
     public function syncPermission(array $permissions)
     {
-        $ids = collect($permissions)->transform(function ($permission) {
-            if (is_string($permission) && str($permission)->isUlid()) {
-                return $permission;
+        // ⚡ Bolt: Fast-path for bulk permission sync to avoid N+1 queries.
+        // We extract the string names, do a bulk query to find existing permissions,
+        // and only execute firstOrCreate() for the missing ones.
+        $stringNames = [];
+        foreach ($permissions as $permission) {
+            if (is_string($permission) && ! str($permission)->isUlid() && ! is_numeric($permission)) {
+                $stringNames[] = $permission;
             }
-            if (is_numeric($permission)) {
-                return (int) $permission;
-            }
-            if (is_string($permission)) {
-                $permissionObject = app(config('laravolt.epicentrum.models.permission'))->firstOrCreate(['name' => $permission]);
+        }
 
-                return $permissionObject->getKey();
-            }
-            if ($permission instanceof Model) {
-                return $permission->getKey();
-            }
-        })->filter(function ($id) {
-            if (is_int($id)) {
-                return $id > 0;
-            }
+        $existingPermissions = [];
+        if (! empty($stringNames)) {
+            $existingPermissions = app(config('laravolt.epicentrum.models.permission'))
+                ->whereIn('name', $stringNames)
+                ->get()
+                ->keyBy(fn ($item) => strtolower($item->name))
+                ->all();
+        }
 
-            if (is_string($id)) {
-                return trim($id) !== '';
-            }
+        $ids = collect($permissions)->transform(
+            function ($permission) use (&$existingPermissions) {
+                if (is_string($permission) && str($permission)->isUlid()) {
+                    return $permission;
+                }
+                if (is_numeric($permission)) {
+                    return (int) $permission;
+                }
+                if (is_string($permission)) {
+                    $lowerName = strtolower($permission);
+                    if (isset($existingPermissions[$lowerName])) {
+                        return $existingPermissions[$lowerName]->getKey();
+                    }
 
-            return false;
-        });
+                    $permissionObject = app(config('laravolt.epicentrum.models.permission'))->firstOrCreate(['name' => $permission]);
+                    $existingPermissions[$lowerName] = $permissionObject;
+
+                    return $permissionObject->getKey();
+                }
+                if ($permission instanceof Model) {
+                    return $permission->getKey();
+                }
+            }
+        )->filter(
+            function ($id) {
+                if (is_int($id)) {
+                    return $id > 0;
+                }
+
+                if (is_string($id)) {
+                    return trim($id) !== '';
+                }
+
+                return false;
+            }
+        );
 
         $changes = $this->permissions()->sync($ids->toArray());
 

--- a/src/Platform/Services/Acl.php
+++ b/src/Platform/Services/Acl.php
@@ -38,40 +38,43 @@ class Acl
 
     public function syncPermission($refresh = false): Collection
     {
-        return DB::transaction(function () use ($refresh) {
-            if ($refresh) {
-                Schema::disableForeignKeyConstraints();
-                app(config('laravolt.epicentrum.models.permission'))->truncate();
-                Schema::enableForeignKeyConstraints();
-            }
-
-            $items = collect();
-            foreach ($this->permissions() as $name) {
-                $permission = app(config('laravolt.epicentrum.models.permission'))->firstOrNew(['name' => $name]);
-                $status = 'No Change';
-
-                if (! $permission->exists) {
-                    $permission->save();
-                    $status = 'New';
+        return DB::transaction(
+            function () use ($refresh) {
+                if ($refresh) {
+                    Schema::disableForeignKeyConstraints();
+                    app(config('laravolt.epicentrum.models.permission'))->truncate();
+                    Schema::enableForeignKeyConstraints();
                 }
 
-                $items->push(['id' => $permission->getKey(), 'name' => $name, 'status' => $status]);
+                $items = collect();
+                foreach ($this->permissions() as $name) {
+                    $permission = app(config('laravolt.epicentrum.models.permission'))->firstOrNew(['name' => $name]);
+                    $status = 'No Change';
+
+                    if (! $permission->exists) {
+                        $permission->save();
+                        $status = 'New';
+                    }
+
+                    $items->push(['id' => $permission->getKey(), 'name' => $name, 'status' => $status]);
+                }
+
+                // delete unused permissions
+                $permissions = $this->permissions();
+                $permissions[] = '*';
+                $unusedPermissions = app(config('laravolt.epicentrum.models.permission'))
+                    ->whereNotIn('name', $permissions)
+                    ->get();
+
+                foreach ($unusedPermissions as $permission) {
+                    $items->push(['id' => $permission->getKey(), 'name' => $permission->name, 'status' => 'Deleted']);
+                    $permission->delete();
+                }
+
+                $items = $items->sortBy('name');
+
+                return $items;
             }
-
-            // delete unused permissions
-            $permissions = $this->permissions() + ['*'];
-            $unusedPermissions = app(config('laravolt.epicentrum.models.permission'))
-                ->whereNotIn('name', $permissions)
-                ->get();
-
-            foreach ($unusedPermissions as $permission) {
-                $items->push(['id' => $permission->getKey(), 'name' => $permission->name, 'status' => 'Deleted']);
-                $permission->delete();
-            }
-
-            $items = $items->sortBy('name');
-
-            return $items;
-        });
+        );
     }
 }


### PR DESCRIPTION
💡 What:
- Optimized `Role::syncPermission()` by introducing a fast-path that extracts all string permission names and performs a single bulk `whereIn()` query to fetch existing permissions.
- Only calls `firstOrCreate()` for permissions that were not found in the bulk query.
- Fixed a silent bug in `Acl::syncPermission()` where the array union operator `+` (`$permissions + ['*']`) discarded the `*` element because index `0` was already populated by existing permissions, leading to potential accidental deletion of the superadmin wildcard permission.

🎯 Why:
- The previous implementation in `Role::syncPermission()` executed a separate `firstOrCreate()` lookup query for every single string permission passed to it. This O(N) database scaling creates a significant N+1 bottleneck when syncing large numbers of permissions.
- The bug in `Acl::syncPermission()` could break the core role-based access control system by deleting the superadmin `*` permission during a sync.

📊 Impact:
- Reduces database round-trips from O(N) to O(1) for existing string permissions during role synchronization.
- Eliminates the risk of superadmin permission deletion during ACL sync.

🔬 Measurement:
- Run the test suite (`vendor/bin/pest`) to verify all ACL and Role functionality remains fully intact. You can profile database queries to observe the reduction in `SELECT` statements during bulk permission synchronization.

---
*PR created automatically by Jules for task [14151031186381515736](https://jules.google.com/task/14151031186381515736) started by @qisthidev*