### PR TITLE
⚡ Bolt: Optimize Acl::syncPermission to prevent N+1 queries

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,6 @@
 ## 2024-05-11 - Optimized Permission Check
 **Learning:** Laravolt's `HasRoleAndPermission` and `Role` models do dynamic query checks or `contains` lookups when `hasPermission` is called. Since permissions are eager-loaded, doing a `contains` operation manually can bypass `app(config(...))` overhead and Model instantiation.
 **Action:** Overrode `_hasPermission` in models to utilize eager-loaded relations properly.
+## 2024-05-12 - Bulk Permission Sync N+1
+**Learning:** In `Laravolt\Platform\Services\Acl`, generating missing permissions in the `syncPermission` method originally used a loop that fired `firstOrNew` for every permission, resulting in an O(N) database query bottleneck. Furthermore, `+` array union was incorrectly dropping the `*` permission when appending it to numerically indexed permissions array.
+**Action:** Always batch fetch using `whereIn` combined with `keyBy(fn ($item) => strtolower($item->name))` for in-memory mapping before falling back to `firstOrCreate`. Never use `+` for numerically-indexed array concatenation.

--- a/src/Platform/Services/Acl.php
+++ b/src/Platform/Services/Acl.php
@@ -38,40 +38,58 @@ class Acl
 
     public function syncPermission($refresh = false): Collection
     {
-        return DB::transaction(function () use ($refresh) {
-            if ($refresh) {
-                Schema::disableForeignKeyConstraints();
-                app(config('laravolt.epicentrum.models.permission'))->truncate();
-                Schema::enableForeignKeyConstraints();
-            }
-
-            $items = collect();
-            foreach ($this->permissions() as $name) {
-                $permission = app(config('laravolt.epicentrum.models.permission'))->firstOrNew(['name' => $name]);
-                $status = 'No Change';
-
-                if (! $permission->exists) {
-                    $permission->save();
-                    $status = 'New';
+        return DB::transaction(
+            function () use ($refresh) {
+                if ($refresh) {
+                    Schema::disableForeignKeyConstraints();
+                    app(config('laravolt.epicentrum.models.permission'))->truncate();
+                    Schema::enableForeignKeyConstraints();
                 }
 
-                $items->push(['id' => $permission->getKey(), 'name' => $name, 'status' => $status]);
+                $items = collect();
+                $registeredPermissions = $this->permissions();
+                $existingPermissions = collect();
+
+                if (! empty($registeredPermissions)) {
+                    // Batch fetch existing permissions to avoid N+1 query issue
+                    $existingPermissions = app(config('laravolt.epicentrum.models.permission'))
+                        ->whereIn('name', $registeredPermissions)
+                        ->get()
+                        ->keyBy(fn ($item) => strtolower($item->name));
+                }
+
+                foreach ($registeredPermissions as $name) {
+                    $lowerName = strtolower($name);
+
+                    if ($existingPermissions->has($lowerName)) {
+                        $permission = $existingPermissions->get($lowerName);
+                        $status = 'No Change';
+                    } else {
+                        // Fallback to firstOrCreate for missing permissions
+                        $permission = app(config('laravolt.epicentrum.models.permission'))->firstOrCreate(['name' => $name]);
+                        $status = 'New';
+                    }
+
+                    $items->push(['id' => $permission->getKey(), 'name' => $name, 'status' => $status]);
+                }
+
+                // delete unused permissions
+                $permissions = $this->permissions();
+                $permissions[] = '*';
+
+                $unusedPermissions = app(config('laravolt.epicentrum.models.permission'))
+                    ->whereNotIn('name', $permissions)
+                    ->get();
+
+                foreach ($unusedPermissions as $permission) {
+                    $items->push(['id' => $permission->getKey(), 'name' => $permission->name, 'status' => 'Deleted']);
+                    $permission->delete();
+                }
+
+                $items = $items->sortBy('name');
+
+                return $items;
             }
-
-            // delete unused permissions
-            $permissions = $this->permissions() + ['*'];
-            $unusedPermissions = app(config('laravolt.epicentrum.models.permission'))
-                ->whereNotIn('name', $permissions)
-                ->get();
-
-            foreach ($unusedPermissions as $permission) {
-                $items->push(['id' => $permission->getKey(), 'name' => $permission->name, 'status' => 'Deleted']);
-                $permission->delete();
-            }
-
-            $items = $items->sortBy('name');
-
-            return $items;
-        });
+        );
     }
 }


### PR DESCRIPTION
💡 **What**
Refactored `syncPermission` in `Laravolt\Platform\Services\Acl` to fetch all existing registered permissions in a single `whereIn` query before falling back to `firstOrCreate`. Fixed a bug where array union (`+`) accidentally deleted the `*` permission.

🎯 **Why**
Previously, when the system booted and synchronized a large number of permissions, the application executed an O(N) database query pattern (1 query per permission) which degraded application startup and sync performance.

📊 **Impact**
Reduces the number of initial database read queries from O(N) to O(1) when syncing permissions, drastically improving sync performance in apps with dozens of permissions.

🔬 **Measurement**
Run `test_acl_perf.php` (if it existed) or the pest suite `DB_CONNECTION=sqlite DB_DATABASE=:memory: ./vendor/bin/pest tests/Feature/Acl` to observe speedup and verify correctness.

---
*PR created automatically by Jules for task [7665223387338269165](https://jules.google.com/task/7665223387338269165) started by @qisthidev*