### PR TITLE
⚡ Bolt: [performance improvement] Batch database session deletion to prevent N+1 queries

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,6 @@
 ## 2024-05-11 - Optimized Permission Check
 **Learning:** Laravolt's `HasRoleAndPermission` and `Role` models do dynamic query checks or `contains` lookups when `hasPermission` is called. Since permissions are eager-loaded, doing a `contains` operation manually can bypass `app(config(...))` overhead and Model instantiation.
 **Action:** Overrode `_hasPermission` in models to utilize eager-loaded relations properly.
+## 2026-08-04 - Optimization: Batch Database Session Deletion to Prevent N+1 Checks
+**Learning:** Checking database schemas `Schema::hasTable()` inside iterative structures triggering cascading operations silently introduces O(N) hidden database queries.
+**Action:** When updating systems that depend on database meta-checks for multiple users (like invalidating sessions), accumulate the IDs and branch the data pipeline to execute single batched `whereIn()` queries with only a single schema resolution upfront.

--- a/src/Platform/Services/AccessControlInvalidator.php
+++ b/src/Platform/Services/AccessControlInvalidator.php
@@ -22,10 +22,18 @@ class AccessControlInvalidator
 
     public function invalidateUsers(iterable $users): void
     {
+        $userIds = [];
+
         foreach ($users as $user) {
             if ($user instanceof Model) {
-                $this->invalidateUser($user);
+                $userId = $user->getKey();
+                Cache::forget("users.{$userId}.permissions");
+                $userIds[] = $userId;
             }
+        }
+
+        if (! empty($userIds)) {
+            $this->deleteDatabaseSessions($userIds);
         }
     }
 
@@ -40,7 +48,15 @@ class AccessControlInvalidator
                 return;
             }
 
-            DB::connection($connection)->table($table)->where('user_id', $userId)->delete();
+            $query = DB::connection($connection)->table($table);
+
+            if (is_iterable($userId)) {
+                $query->whereIn('user_id', $userId);
+            } else {
+                $query->where('user_id', $userId);
+            }
+
+            $query->delete();
         } catch (Throwable) {
             // Session invalidation is best-effort because Laravolt can run with
             // non-database session drivers or applications without session table.


### PR DESCRIPTION
💡 What:
Refactored `invalidateUsers` in `AccessControlInvalidator.php` to extract user IDs in a loop and execute a single batched `whereIn('user_id', $userIds)` query for database session deletion.

🎯 Why:
Previously, passing a list of users to `invalidateUsers` triggered `invalidateUser()` in a loop. Because `deleteDatabaseSessions()` performs a `Schema::hasTable` and `Schema::hasColumn` check per call before executing the `DELETE` statement, this caused `N * 3` database queries (two schema queries and one deletion query per user). Batching the IDs reduces this from O(N) to O(1) database interactions.

📊 Impact:
Reduces database queries related to session invalidation for bulk operations from O(N) to O(1). A bulk action on 100 users saves approximately 300 database queries, providing a measurable reduction in latency and database load.

🔬 Measurement:
1. Run the test suite: `DB_CONNECTION=sqlite DB_DATABASE=:memory: vendor/bin/pest`.
2. Inspect queries using Laravel Debugbar or Telescope when bulk-updating user roles/permissions to verify only one `DELETE` query is sent to the `sessions` table.

---
*PR created automatically by Jules for task [7263185663554668905](https://jules.google.com/task/7263185663554668905) started by @qisthidev*